### PR TITLE
Surface credential health in admin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,83 @@
+# OrionPulse environment configuration
+# Replace the placeholders with your production secrets before running the app locally.
+
+# --- Supabase ---------------------------------------------------------------
+SUPABASE_PROJECT_ID=jqhmxrzzqzlwongbrdio
+SUPABASE_URL=https://jqhmxrzzqzlwongbrdio.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=sb_secret_wW6d264OdEH_SEtzBEtcBw_O7gvl6UK
+
+NEXT_PUBLIC_SUPABASE_URL=https://jqhmxrzzqzlwongbrdio.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=sb_publishable_q7ihiXY5sLmlcYnfPrNCZQ_lCr9j-Ve
+
+# Optional overrides for workspace selection bootstrap
+ORIONPULSE_WORKSPACE_ID=
+ORIONPULSE_DEFAULT_WORKSPACE_NAME=OrionPulse HQ
+ORIONPULSE_DEFAULT_TERRITORIES=MQ,GP,GF
+
+# --- OpenAI GPT-5 Agents ----------------------------------------------------
+OPENAI_API_KEY=
+OPENAI_AGENT_ID=
+OPENAI_API_BASE=https://api.openai.com/v1
+DBT_SEMANTIC_CONNECTION=orionpulse_semantic
+
+# --- MCP Servers -----------------------------------------------------------
+MCP_GOOGLE_ADS_URL=stdio:npx google-ads-mcp
+MCP_GOOGLE_ADS_STATUS=unknown
+GOOGLE_ADS_DEVELOPER_TOKEN=
+GOOGLE_ADS_CLIENT_ID=
+GOOGLE_ADS_CLIENT_SECRET=
+GOOGLE_ADS_REFRESH_TOKEN=
+GOOGLE_ADS_LOGIN_CUSTOMER_ID=
+GOOGLE_ADS_YAML=
+
+MCP_META_ADS_URL=stdio:npx meta-mcp
+MCP_META_ADS_STATUS=unknown
+META_ACCESS_TOKEN=
+META_APP_ID=
+META_APP_SECRET=
+
+MCP_LINKEDIN_ADS_URL=https://linkedinads.radiateb2b.com/sse
+MCP_LINKEDIN_ADS_STATUS=online
+MCP_LINKEDIN_ADS_TOKEN=
+
+MCP_TIKTOK_ADS_URL=stdio:npx tiktok-ads-mcp
+MCP_TIKTOK_ADS_STATUS=unknown
+TIKTOK_APP_ID=
+TIKTOK_APP_SECRET=
+TIKTOK_ACCESS_TOKEN=
+
+MCP_AMAZON_ADS_URL=https://app.marketplaceadpros.com/mcp
+MCP_AMAZON_ADS_STATUS=unknown
+MCP_AMAZON_ADS_TOKEN=
+
+MCP_GOOGLE_ANALYTICS_URL=stdio:npx google-analytics-mcp
+MCP_GOOGLE_ANALYTICS_STATUS=unknown
+GOOGLE_APPLICATION_CREDENTIALS=
+GOOGLE_PROJECT_ID=
+
+MCP_DATA_COMMONS_URL=https://mcp.datacommons.org/sse
+MCP_DATA_COMMONS_STATUS=online
+
+MCP_SLACK_URL=stdio:npx slack-mcp-server
+MCP_SLACK_STATUS=unknown
+SLACK_MCP_XOXP_TOKEN=
+SLACK_MCP_XOXC_TOKEN=
+SLACK_MCP_API_KEY=
+
+MCP_NOTION_URL=https://mcp.notion.com/mcp
+MCP_NOTION_STATUS=online
+
+MCP_ATLASSIAN_URL=https://mcp.atlassian.com/sse
+MCP_ATLASSIAN_STATUS=unknown
+MCP_ATLASSIAN_TOKEN=
+
+MCP_GOOGLE_DRIVE_URL=stdio:npx google-drive-mcp
+MCP_GOOGLE_DRIVE_STATUS=unknown
+GOOGLE_DRIVE_CLIENT_ID=
+GOOGLE_DRIVE_CLIENT_SECRET=
+GOOGLE_DRIVE_REFRESH_TOKEN=
+
+MCP_DAGSTER_URL=stdio:npx mcp-server-dagster
+MCP_DAGSTER_STATUS=unknown
+DAGSTER_GRAPHQL_URL=
+DAGSTER_API_TOKEN=

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next", "next/core-web-vitals"],
+  "rules": {
+    "react/jsx-key": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+out
+.env*
+!.env.example
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+.vercel

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,346 @@
+# OrionPulse — SaaS Marketing Intelligence Suite
+
+## 1. Vision & Value Proposition
+- **Target personas**: traffic managers, data analysts, growth teams operating multi-territory (MQ/GP/GF) performance portfolios.
+- **Core promise**: unify paid media intelligence, planning and actions through a design-forward, MCP-native SaaS with embedded GPT-5 copilots.
+- **Guiding principles (2025)**:
+  1. *Operational-first*: every screen drives a decision, an insight, or an action (no vanity analytics).
+  2. *LLM-native architecture*: GPT-5 agents orchestrate queries, insights and workflows via Model Context Protocol (MCP) servers.
+  3. *Composable data stack*: leverage best-in-class managed services (Supabase, dbt Semantic Layer, Apache Iceberg, DuckDB-in-browser) to stay flexible and cost-efficient.
+  4. *Human-in-the-loop guardrails*: every automated recommendation exposes provenance, confidence, and approval workflows.
+
+## 2. Platform Architecture Overview
+```
+User (Web / Mobile) ─┬─▶ Next.js 15 App Router (React Server Components, Suspense)
+                     │        │
+                     │        ├─▶ Design System (Radix UI 2025 + Tailwind v4 + Plasmic tokens)
+                     │        ├─▶ Data Viz Engine (AntV S2, ECharts 6, Observable Plot)
+                     │        └─▶ Voice/Multimodal Copilot Widget (GPT-5 Realtime SDK)
+                     │
+                     ├─▶ Edge Middleware (Next Middleware, OpenFeature, LaunchDarkly)
+                     │
+                     └─▶ BFF Layer (tRPC v12 + Supabase Edge Functions)
+                                  │
+                                  ├─▶ Supabase Postgres (Hyperscale) + Row Level Security
+                                  ├─▶ Supabase Storage (assets, creative previews)
+                                  ├─▶ Supabase Auth (Passkey, OAuth, SSO via SAML/OIDC)
+                                  │
+                                  ├─▶ dbt Core + dbt Semantic Layer (metrics contracts)
+                                  ├─▶ Data Warehouse (Snowflake Arctic or BigQuery)
+                                  ├─▶ Lakehouse (Iceberg on GCS via Upsolver)
+                                  │
+                                  ├─▶ Orchestration (Dagster Cloud 2025, Great Expectations 2.0)
+                                  ├─▶ Feature Store (Feast 1.0 hybrid)
+                                  │
+                                  └─▶ MCP Hub (Node MCP Router) ↔ Remote MCP Servers (Google, Meta, LinkedIn, TikTok, Amazon Ads)
+                                             │
+                                             └─▶ GPT-5 Agent Runtime (OpenAI Agents API) + Guardrails (OpenPolicyAgent + HoneyHive)
+```
+
+## 3. Key Components (2025 best-of-breed)
+| Layer | Choice (2025) | Rationale |
+| --- | --- | --- |
+| Front-end | Next.js 15 (App Router, RSC), TanStack Router 1.0, Radix UI 3.0, Tailwind CSS v4, Framer Motion 8 | Server Components for streaming dashboards, top-tier accessibility, design tokens, animation. |
+| Data Viz | AntV S2 (pivot grid), ECharts 6 (GPU rendering), Observable Plot 2.0, Deck.gl 9 for geospatial | Combines performance, custom storytelling, interactive what-if sliders. |
+| Collaboration | Liveblocks 2.0, Confluence-style commenting, templatized notes | Real-time collaboration on dashboards, embedded annotation threads. |
+| Backend | Supabase (Postgres + Auth + Edge), tRPC v12, Node 20 LTS, Rust microservices for heavy compute | Managed Postgres with RLS, typed end-to-end API layer, Rust for MMM simulations. |
+| Data Platform | Snowflake Arctic (or BigQuery) + Iceberg Lake, dbt Cloud 2025, Dagster Cloud, Great Expectations 2.0 | Unified metrics, declarative orchestration, strong data quality enforcement. |
+| AI/LLM | OpenAI GPT-5 Agents API, Realtime SDK, LangGraph 0.2, Guardrails (Open Policy Agent, NeMo Guardrails) | Multi-modal copilot, tool orchestration, safe execution. |
+| MCP | Node MCP Router (house-built) + remote servers: google-marketing-solutions/google_ads_mcp_server, wiiip/meta-mcp, radiateb2b/mcp-linkedinads, AdsMCP/tiktok-ads-mcp, MarketplaceAdPros/amazon-ads-mcp | Plug-and-play ad platform connectivity via JSON-RPC 2.0. |
+| Observability | OpenTelemetry 1.10, Axiom/Sentry for tracing, Datafold for diff checks, OpenLineage for data jobs | Holistic monitoring from front-end to ETL. |
+| Security | Supabase RLS, Auth0 B2B, StepSecurity Supply Chain Guardian, Vault + KMS, SOC2 automation (Drata) | Compliance-ready stack with minimal overhead. |
+
+## 4. Page & Experience Architecture (≥10 screens)
+1. **Global Overview** – cross-channel KPI heatmaps, territory tabs (MQ/GP/GF), anomalies timeline, GPT-5 narrative summary.
+2. **Performance Deep Dive** – customizable pivot (AntV S2) with campaign/adset/ad breakdown, scenario filters, one-click cohort saves.
+3. **Territory Command Center** – map (Deck.gl) with spend vs ROAS vs saturation, local events overlay, targeted alerts.
+4. **Creative Intelligence Studio** – gallery of creatives (image/video) with fatigue score, CV insights, voice transcripts, recommended next briefs.
+5. **Copilot Console** – conversational interface (text/voice) with prompt history, saved queries, action approvals, runbook execution log.
+6. **Opportunity Pipeline** – prioritized list of anomalies/opportunities, severity scoring, status (open, in-progress, executed) with assignment.
+7. **What-if Planner** – MMM & budget simulator, constraint builder, scenario comparison (table + chart + GPT explanation).
+8. **Attribution & Lift Lab** – clean room connectors, incremental tests dashboard, CAPI health, matched conversion funnels.
+9. **Alerts & Runbooks** – configuration of alert rules, channel thresholds, scheduling, freeze windows, integration settings (Slack/Teams/Email).
+10. **Profile & Workspace Settings** – user profile, notification preferences, client/territory memberships, API keys, access logs.
+11. **Admin Control Plane** – tenant management, feature flags, usage analytics, MCP status monitors, audit exports.
+12. **Report Builder & Library** – drag-and-drop report templates, white-label branding, scheduling, signature workflow.
+
+Pages are linked via a unified navigation shell with context-aware breadcrumbs, quick actions, and GPT-5 suggested next best views.
+
+## 5. Information Architecture & Navigation
+- **Global navigation**: left rail (Overview, Performance, Territory, Opportunities, Planner, Creative, Attribution, Alerts, Reports, Copilot, Admin).
+- **Contextual top bar**: territory selector (MQ/GP/GF), date range, live status (data freshness), quick search (command palette + GPT).
+- **Workspaces**: multi-tenant isolation by client/brand; each workspace inherits templates but allows overrides (metrics weighting, color palette).
+- **Linking strategy**:
+  - Drill-down paths (Overview → Performance → Campaign detail → Creative asset).
+  - Copilot deep links to relevant page + filters when it surfaces insights.
+  - Alerts include “Open in Planner” or “Trigger runbook” CTA with prefilled context.
+
+## 6. Data Architecture & Pipelines
+1. **Ingestion**
+   - Scheduled pulls via Dagster sensors hitting MCP servers (HTTP SSE for streaming).
+   - Fallback REST integrations for long-tail metrics (e.g., creative previews via Google Ads API assets endpoint).
+   - Near-real-time webhooks (Meta Marketing API) processed by Supabase Functions, appended to Kafka-on-Redpanda for event storage.
+2. **Staging & Quality**
+   - Raw tables in Iceberg (partitioned by date, platform, account).
+   - Great Expectations suites covering schema drift, null checks, spend vs impressions ratio, naming conventions.
+   - Data contracts defined in YAML, versioned, validated in CI (GitHub Actions + dbt tests).
+3. **Modeling**
+   - dbt projects produce `dim_*`, `fact_*`, `fct_performance_daily`, `fct_creative_metrics`, `fct_mmm_features`.
+   - Metrics defined in dbt Semantic Layer with contracts (e.g., CPA = spend / conv, guard against divide-by-zero).
+4. **Serving**
+   - Semantic Layer exposed to front-end via MetricFlow GraphQL + DuckDB caches for sub-second slicing.
+   - Materialized tiles (Superset of 2025 “delta caches”) for high-traffic charts.
+   - Feature Store pushes features to ML services (anomaly detection, MMM).
+5. **Historical Storage**
+   - Iceberg lake retains raw/backfill data (7-year retention) to support MMM.
+   - Snapshots of metrics stored nightly for reproducible reports.
+
+## 7. MCP Integration Blueprint
+- **MCP Hub**: Node.js service managing registration, authentication, health checks of remote servers; supports stdio for dev, HTTP SSE for prod.
+- **Server registry**: config file mapping platform → endpoint, auth scope, rate limit policy.
+- **Credential vaulting**: Supabase Secrets stores per-tenant OAuth tokens encrypted; rotating refresh tokens via scheduler.
+- **Rate limiting & retries**: Token bucket per platform; exponential backoff with jitter; queue (BullMQ 5) ensures fairness across tenants.
+- **Action guardrails**:
+  - Policy engine (OPA) reads YAML guardrail definitions (max budget change %, black-out windows).
+  - Dry-run mode simulates MCP call and returns predicted impact (with GPT-5 explanation).
+  - Approval workflows stored in Supabase (status: pending, approved, rejected, auto-expire).
+- **LLM tool definitions**: Each MCP server registered as GPT-5 tool with schema (GAQL query builder, creative update action, etc.).
+
+## 8. AI Copilot Architecture
+- **Runtime**: OpenAI GPT-5 Agents API with Realtime SDK for multimodal (text, voice, screen recording).
+- **Toolset**:
+  1. `metrics_query`: interacts with dbt Semantic Layer (SQL generator + summarizer).
+  2. `mcp_google_ads`, `mcp_meta_ads`, etc.: remote MCP actions.
+  3. `playbook_runner`: executes runbooks stored as YAML (Dagster job triggers).
+  4. `insight_explain`: uses internal RAG over docs (naming policies, best practices, MQ/GP/GF runbooks).
+- **Memory**: Short-term conversation stored client-side (secure session), long-term insights saved as “Copilot Notes” in Supabase.
+- **Trust layer**: HoneyHive Safety evals + red teaming suite; all agent outputs passed through moderation & policy guardrails.
+- **Multimodal UX**: voice input (WebRTC) with Whisper-Next, screen annotations via Canvas; ability to record quick Loom-style summaries.
+
+## 9. Backend Services & Supabase Usage
+- **Auth**: Supabase Auth with passkeys, OAuth (Google, Microsoft), enterprise SSO via Auth0 B2B bridging; enforce MFA, device trust.
+- **Database schema (core tables)**:
+  - `workspaces`, `users`, `memberships`, `roles`, `clients`, `territories`.
+  - `data_sources`, `credentials`, `mcp_connections`, `sync_jobs`, `sync_logs`.
+  - `insights`, `opportunities`, `actions`, `approvals`, `runbooks`.
+  - `reports`, `report_templates`, `exports`.
+  - `alerts`, `alert_rules`, `alert_events`, `playbook_executions`.
+- **Implementation note**: la migration `supabase/migrations/202409250001_core.sql` provisionne ces entités avec UUID natif et servira de socle aux politiques RLS.
+- **APIs**: tRPC routers auto-generated from Zod schemas; GraphQL gateway (Helix) for external integrations.
+- **Implementation note**: `server/api/root.ts` expose déjà `performance` et `opportunities` via `/api/trpc` (adapter fetch) pour connecter rapidement le front.
+- **Edge Functions**: inbound webhooks, scheduled syncs, quick computations (e.g., UTM validation), Slack slash commands.
+- **Background processing**: Supabase Queue + Worker (Rust) for heavy tasks (MMM, clustering).
+
+## 10. Data Science & Intelligence Modules
+1. **Anomaly Detection**: Prophet Next + Kats 3.0 ensemble, using feature store metrics; outputs severity & suggested action.
+2. **Creative Intelligence**: CLIP-ViT-Next + AudioLM for transcript sentiment; fatigue detection via survival analysis.
+3. **MMM & Planner**: Bayesian MMM built in PyMC 5, accelerated with JAX on Cloud TPU v5e; interactive what-if solver (Optax).
+4. **Attribution**: Clean room connectors (Google Ads Data Hub, Meta Advanced Analytics) via secure data shares; incremental lift experiments orchestrated in Dagster.
+5. **Opportunity Prioritization**: Multi-factor scoring (impact, urgency, confidence, effort) stored per opportunity.
+
+## 11. Security, Compliance & Governance
+- **RLS**: enforce workspace/client isolation at SQL level; dynamic filters by territory.
+- **PII Handling**: hashed customer IDs, differential privacy for aggregated outputs, data minimization policy.
+- **Auditability**: OpenLineage tracks ETL lineage; every MCP action logged with before/after snapshot, approval trace.
+- **Secrets**: HashiCorp Vault + Supabase Secrets; rotation policies; break-glass process.
+- **Compliance**: SOC2 Type II-ready; GDPR/CCPA controls; Data Processing Agreements per client; retention policies configurable.
+
+## 12. Deployment & DevOps
+- **Environments**: Dev (preview deployments via Vercel), Staging (Supabase project + Snowflake sandbox), Prod (Vercel Enterprise + Supabase prod + Snowflake prod).
+- **CI/CD**: GitHub Actions (lint, type check, Playwright, dbt tests); Vercel Preview per PR; Dagster asset job tests; security scans (Snyk, Dependabot).
+- **Infrastructure as Code**: Pulumi (TypeScript) managing Supabase configs, Snowflake objects, secrets, MCP hub deployments (Cloud Run or Fly.io).
+- **Observability**: OpenTelemetry traces to Axiom; SLO dashboards (Grafana Cloud); alert routing via PagerDuty.
+
+## 13. Roadmap (18-month horizon)
+| Phase | Timeline | Objectives |
+| --- | --- | --- |
+| **Phase 0 — Foundations** | Month 0-2 | Set up Supabase, Auth, base schema, design system, initial ingestion via MCP read-only, dbt staging. |
+| **Phase 1 — Insight MVP** | Month 3-5 | Dashboards (Overview, Performance, Territory), anomaly detection v1, exports, alert thresholds. |
+| **Phase 2 — Copilot & Actions** | Month 6-9 | GPT-5 copilot beta, guardrails, approvals, runbook execution, admin control plane. |
+| **Phase 3 — Intelligence Expansion** | Month 10-14 | Creative intelligence, MMM planner, clean room integration, white-label report builder. |
+| **Phase 4 — Scale & Marketplace** | Month 15-18 | Multi-tenant hardening, marketplace integrations (CRM, reverse ETL), usage-based billing, advanced governance. |
+
+## 14. Implementation Backlog (rolling 90-day view)
+| Stream | Epic | Key Deliverables | Milestones |
+| --- | --- | --- | --- |
+| Platform | Supabase foundation | Infrastructure-as-code (Pulumi) for Supabase projects, Auth providers, storage buckets; baseline RLS policies; observability stack (Axiom, Grafana). | Week 2: IaC deployable, Week 4: Auth + RLS live, Week 6: audit logs shipping. |
+| Data | Unified model v1 | Dagster ingestion jobs (Google/Meta/LinkedIn read-only), Great Expectations suites, dbt staging models + semantic metrics (Spend, Impressions, Clicks, Conversions, CPA, ROAS). | Week 3: MCP pull → raw tables, Week 6: dbt fct_performance_daily, Week 8: semantic API contract. |
+| Experience | Dashboard shell | Navigation layout, territory/date context providers, design tokens, chart primitives (AntV S2 + ECharts), Liveblocks presence. | Week 4: navigation + auth gating, Week 7: Overview dashboard, Week 9: saved views. |
+| Copilot | GPT-5 embed | Realtime SDK widget, MCP tool registration, NL→SQL chain (LangGraph), approvals UI. | Week 5: copilot widget stub, Week 8: metrics_query end-to-end, Week 10: action approvals pilot. |
+| Intelligence | Anomaly engine | Feature store sync, Prophet Next ensemble pipeline, alert thresholds + Slack integration. | Week 6: feature registry, Week 9: anomalies surfacing, Week 11: runbook recommendation loop. |
+| Governance | Guardrails & audits | OPA policy repo, dry-run simulator, audit timeline view, SOC2 evidence automation. | Week 5: policies scaffolding, Week 8: dry-run responses, Week 12: audit exports. |
+
+## 15. Supabase Schema Blueprint (DDL excerpt)
+```sql
+-- Workspaces & membership
+create table workspaces (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  slug text unique not null,
+  plan text default 'internal',
+  created_at timestamptz default now()
+);
+
+create table users (
+  id uuid primary key,
+  email text unique not null,
+  full_name text,
+  avatar_url text,
+  created_at timestamptz default now()
+);
+
+create table memberships (
+  workspace_id uuid references workspaces on delete cascade,
+  user_id uuid references users on delete cascade,
+  role text check (role in ('owner','admin','analyst','viewer')),
+  territories text[] default array[]::text[],
+  primary key (workspace_id, user_id)
+);
+
+-- Data connectors & sync state
+create table data_sources (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid references workspaces,
+  provider text check (provider in ('google_ads','meta_ads','linkedin_ads','tiktok_ads','amazon_ads')),
+  status text default 'inactive',
+  created_at timestamptz default now()
+);
+
+create table credentials (
+  id uuid primary key default gen_random_uuid(),
+  data_source_id uuid references data_sources on delete cascade,
+  access_token text encrypt,
+  refresh_token text encrypt,
+  expires_at timestamptz,
+  scopes text[],
+  last_rotated_at timestamptz
+);
+
+create table mcp_connections (
+  id uuid primary key default gen_random_uuid(),
+  data_source_id uuid references data_sources,
+  endpoint_url text not null,
+  transport text check (transport in ('stdio','http_sse')),
+  health jsonb,
+  last_checked_at timestamptz
+);
+
+create table sync_jobs (
+  id uuid primary key default gen_random_uuid(),
+  data_source_id uuid,
+  job_type text check (job_type in ('ingest','backfill','action','audit')),
+  started_at timestamptz,
+  finished_at timestamptz,
+  status text check (status in ('queued','running','succeeded','failed','cancelled')),
+  payload jsonb,
+  result jsonb
+);
+
+create table insights (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid,
+  title text,
+  description text,
+  source text,
+  severity text,
+  status text,
+  created_at timestamptz default now(),
+  resolved_at timestamptz
+);
+
+alter table workspaces enable row level security;
+alter table memberships enable row level security;
+alter table data_sources enable row level security;
+alter table insights enable row level security;
+```
+
+> **RLS Policy Skeleton**: `USING (workspace_id = auth.uid() -> memberships)` combined with helper views ensures users only view data where they have membership; Supabase pg_graphql leverages the same policies for external consumers.
+
+## 16. API Surface & Integration Map
+- **tRPC Routers**
+  - `auth`: session, invitations, passkey enrollment, workspace switching.
+  - `analytics`: semantic metric queries (proxy to dbt SL), saved views CRUD.
+  - `insights`: list/acknowledge/assign insights, log actions taken.
+  - `planner`: scenario CRUD, MMM solver invocations, exports.
+  - `copilot`: chat sessions, tool invocation signatures, approval workflow endpoints.
+  - `admin`: tenant usage, feature flags, MCP health dashboards.
+- **Edge Functions**
+  - `ingest-webhook`: receive Meta/LinkedIn push updates, enqueue Dagster materializations.
+  - `runbook-trigger`: invoked by GPT-5 guardrails after approval; posts to Dagster Cloud or Supabase Queue.
+  - `report-export`: orchestrates PDF/PPT generation, stores in Supabase Storage, notifies users.
+- **External Integrations**
+  - Slack/Teams (alert webhooks, slash commands), Google Drive (report sync), Notion/Confluence (insight embeds), CRM (HubSpot/Salesforce) via reverse ETL.
+
+## 17. Front-end Composition & Design System
+- **Layout primitives**: `AppShell`, `WorkspaceSwitcher`, `TerritoryTabs`, `LiveStatusPill`, `CommandPalette`.
+- **Visualization components**: `KpiTile`, `TrendSpark`, `HeatMatrix`, `GeoChoropleth`, `ScenarioPlayground`, `CreativeCard`, `AnomalyTimeline`.
+- **Copilot UI**: floating widget with voice waveform, context chips, approval modals (Radix Dialog), transcript history synced with Supabase Realtime.
+- **State management**: React Server Components for data fetch, TanStack Query for client cache, Zustand for UI state (filters, layout), Liveblocks for collaboration cursors/comments.
+- **Accessibility & internationalization**: WCAG 2.2 AA, directional layouts (LTR/RTL support), locale packs for MQ/GP/GF territories, numeric formatting service.
+
+## 18. Data Pipeline Scheduling & SLAs
+- **Ingestion cadence**
+  - Google Ads: hourly incremental via `search_stream` (GAQL) per active account; daily backfill for trailing 30 days.
+  - Meta Ads: every 2 hours (insights endpoint), webhook deltas for actions/conversions.
+  - LinkedIn Ads: daily (reporting constraints), focus on MQ/GP/GF priority accounts.
+  - TikTok & Amazon Ads: every 4 hours, align with platform rate limits.
+- **SLA targets**
+  - Freshness: < 90 minutes for Google/Meta, < 4 hours others.
+  - Accuracy: < 0.5% variance vs platform UI for core KPIs.
+  - Availability: 99.5% API uptime for dashboards; 99% for copilot tools.
+- **Monitoring**: Dagster asset sensors send metrics to Prometheus; anomaly thresholds trigger PagerDuty; MCP health hearts aggregated in Admin Control Plane.
+
+## 19. GPT-5 Agent Workflows (examples)
+1. **Insight synthesis**
+   - Trigger: user asks “Pourquoi le CPA Meta augmente en GP ?”
+   - Flow: `metrics_query` pulls CPA trend → GPT compares vs previous period → `insight_explain` references fatigue policy → surfaces chart + recommended action.
+2. **Action with guardrails**
+   - Trigger: anomaly engine flags overspend.
+   - Flow: GPT drafts action (reduce budget 20%) → guardrail policy checks limits & blackout windows → dry-run via MCP → approval modal shown → once approved, `mcp_meta_ads` executes.
+3. **Runbook automation**
+   - Trigger: user invokes “génère un rapport MQ hebdo”.
+   - Flow: GPT selects template → `report-export` function generates PDF → GPT writes executive summary → sends to Slack channel.
+
+## 20. Reliability & Observability Plan
+- **SLOs**: define per domain (Dashboard load P95 < 3.5s, Copilot tool latency < 6s, Dagster ingestion success > 98%).
+- **Telemetry**: OpenTelemetry auto-instrumentation (front-end + backend), logs to Axiom, traces to Tempo-compatible store, metrics to Prometheus.
+- **Testing**: Playwright visual regression for dashboards, contract tests for MCP integrations, chaos tests (latency injection) on MCP hub, dbt slim CI for data models.
+- **Resilience**: Circuit breakers on MCP calls (Polly.js), queue-based retries, blue/green deploy for Edge Functions, snapshot & rollback for Supabase schema via Migra.
+
+## 21. Risks & Mitigations
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| MCP server instability (community maintained) | Data gaps, failed actions | Implement health scoring, auto-fallback to native API, maintain fork with tests, cache critical metrics. |
+| GPT-5 tool hallucinations | Erroneous actions | Strict JSON schema validation, guardrail simulation, human approval mandatory, capture evaluation metrics. |
+| Territory data fragmentation | Poor insights for MQ/GP/GF | Enforce UTM conventions, canonical territory dimension, integrate local datasets (weather, events) for context. |
+| Data privacy compliance | Regulatory breaches | Data minimization, audit logs, DPA templates, encryption at rest, run PII scans (BigID). |
+| MMM compute cost | Budget overrun | Use serverless TPU scheduling, pre-aggregate features, allow coarse sampling, monitor cost dashboards. |
+
+## 22. Open Questions & Next Steps
+- Prioritize initial tenant(s) and datasets (which MQ/GP/GF accounts, historical depth required?).
+- Decide between Snowflake Arctic vs BigQuery based on existing contracts & analyst familiarity.
+- Confirm legal posture for MCP community servers (due diligence, fork strategy, SLAs).
+- Define KPI taxonomy sign-off with stakeholders (naming, calculations, thresholds).
+- Plan beta user testing sessions for copilot workflows (script, success metrics, feedback loop).
+- Align security review cadence (internal audit, external pen-test) before Phase 2 release.
+
+## 23. Best Practices & Operating Model
+- **DesignOps**: maintain design tokens via Figma Tokens API; nightly sync to Tailwind config; accessibility audits (axe-core CI).
+- **DataOps**: monitor freshness SLA (<60 min for spend metrics), incident runbooks, on-call rotation.
+- **LLMOps**: evaluate agent prompts weekly; maintain test suite of 200 canonical queries; track hallucination & action accuracy metrics.
+- **SecOps**: quarterly pen tests, dependency scanning, secrets rotation; automated compliance evidence collection.
+
+## 24. Next Steps Checklist
+1. Validate platform selection with internal stakeholders (Supabase vs Hasura, Snowflake vs BigQuery).
+2. Prototype MCP Hub with Google Ads & Meta servers; confirm authentication flows & rate-limit handling.
+3. Build dbt models for `dim_channel`, `dim_account`, `fact_spend`, `fact_conv`; expose first metrics via Semantic Layer.
+4. Develop design system primitives (Radix, Tailwind) and layout shell; produce moodboard in Figma referencing 2025 component library.
+5. Implement Supabase Auth + Profile page + Admin plane skeleton; ensure RLS policies for multi-tenant isolation.
+6. Wire GPT-5 Copilot sandbox (text-only) to Semantic Layer; add guardrail scaffolding.
+7. Stand up Dagster pipeline for nightly sync; include Great Expectations validations.
+8. Ship MVP of Global Overview, Performance Deep Dive, Alerts screens; gather user feedback.
+9. Expand to Opportunity Pipeline & Copilot Console with action approvals.
+10. Formalize backlog for MMM, Creative Intelligence, Lift Lab modules.
+
+---
+This architecture balances cutting-edge 2025 tooling with pragmatic sequencing, ensuring a design-led, LLM-native SaaS tailored for multi-channel advertising intelligence.

--- a/app/(dashboard)/admin/page.tsx
+++ b/app/(dashboard)/admin/page.tsx
@@ -1,0 +1,426 @@
+import { revalidatePath } from "next/cache";
+import { headers } from "next/headers";
+import { z } from "zod";
+
+import { SectionHeader } from "@/components/ui/section-header";
+import { DataTable, type Column } from "@/components/ui/data-table";
+import { ResourceLink } from "@/components/ui/resource-link";
+import { Pill } from "@/components/ui/pill";
+import { StatusPill } from "@/components/integrations/status-pill";
+import { fetchCredentialSummaries, type CredentialSummary } from "@/lib/data/credentials";
+import { fetchMcpIntegrations, type McpIntegration } from "@/lib/data/integrations";
+import { fetchSyncQueue, type SyncJob } from "@/lib/data/sync";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+import { mcpRegistry, resolveMcpEntry } from "@/lib/mcp/registry";
+
+const backendChecks = [
+  {
+    label: "Supabase tables",
+    status: "Provisionnées",
+    description: "workspaces, data_sources, mcp_connections, sync_jobs, approvals",
+    link: "https://supabase.com/docs/guides/platform/database"
+  },
+  {
+    label: "tRPC routers",
+    status: "En cours",
+    description: "performance.list, opportunities.queue, alerts.upsert, copilot.session",
+    link: "https://trpc.io/docs/v12"
+  },
+  {
+    label: "Edge functions",
+    status: "À planifier",
+    description: "webhooks/meta, webhook/googleads, schedule/dagster-sync",
+    link: "https://supabase.com/docs/guides/functions"
+  }
+];
+
+const queueSyncSchema = z.object({
+  provider: z.string().min(1, "provider manquant")
+});
+
+const syncStatusTone: Record<string, string> = {
+  queued: "border-slate-500/40 bg-slate-500/10 text-slate-200",
+  running: "border-accent/40 bg-accent/10 text-accent",
+  processing: "border-accent/40 bg-accent/10 text-accent",
+  success: "border-emerald-400/40 bg-emerald-400/10 text-emerald-100",
+  succeeded: "border-emerald-400/40 bg-emerald-400/10 text-emerald-100",
+  completed: "border-emerald-400/40 bg-emerald-400/10 text-emerald-100",
+  failed: "border-rose-400/40 bg-rose-400/10 text-rose-200",
+  error: "border-rose-400/40 bg-rose-400/10 text-rose-200"
+};
+
+function toneForSyncStatus(status: string) {
+  return syncStatusTone[status.toLowerCase()] ?? "border-slate-500/40 bg-slate-500/10 text-slate-200";
+}
+
+const credentialStatusTone: Record<CredentialSummary["status"], string> = {
+  active: "border-emerald-400/40 bg-emerald-400/10 text-emerald-100",
+  expiring: "border-amber-300/40 bg-amber-300/10 text-amber-100",
+  expired: "border-rose-400/40 bg-rose-400/10 text-rose-200",
+  missing: "border-slate-500/40 bg-slate-500/10 text-slate-200"
+};
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+export default async function AdminPage() {
+  const workspaceId = await loadWorkspaceId();
+  const [credentials, integrations, syncQueue] = await Promise.all([
+    fetchCredentialSummaries(workspaceId),
+    fetchMcpIntegrations(workspaceId),
+    fetchSyncQueue(workspaceId)
+  ]);
+
+  async function queueSync(formData: FormData) {
+    "use server";
+
+    const parsed = queueSyncSchema.safeParse({
+      provider: formData.get("provider")
+    });
+
+    if (!parsed.success) {
+      throw new Error("Requête invalide : provider manquant");
+    }
+
+    const provider = parsed.data.provider;
+    if (!resolveMcpEntry(provider)) {
+      throw new Error(`Connecteur MCP inconnu: ${provider}`);
+    }
+
+    const supabase = createServiceRoleClient();
+    const workspaceFromRequest = await resolveWorkspaceId(headers(), supabase);
+
+    const { data: connection } = await supabase
+      .from("mcp_connections")
+      .select("id")
+      .eq("workspace_id", workspaceFromRequest)
+      .eq("provider", provider)
+      .maybeSingle();
+
+    if (!connection) {
+      throw new Error("Aucun connecteur enregistré pour ce workspace");
+    }
+
+    const { error } = await supabase.from("sync_jobs").insert({
+      workspace_id: workspaceFromRequest,
+      provider,
+      status: "queued",
+      scheduled_for: new Date().toISOString(),
+      payload: { trigger: "admin-ui" }
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    revalidatePath("/overview");
+    revalidatePath("/admin");
+  }
+
+  const credentialColumns: Column<CredentialSummary>[] = [
+    {
+      header: "Fournisseur",
+      accessor: (row) => (
+        <div className="space-y-1">
+          <p className="font-medium text-slate-100">{row.label}</p>
+          <p className="text-xs text-slate-500">{row.provider}</p>
+        </div>
+      )
+    },
+    {
+      header: "Statut",
+      accessor: (row) => <Pill className={credentialStatusTone[row.status]}>{row.status}</Pill>
+    },
+    {
+      header: "Rotation",
+      accessor: (row) => (row.lastRotatedAt ? new Date(row.lastRotatedAt).toLocaleString("fr-FR") : "Jamais")
+    },
+    {
+      header: "Expiration",
+      accessor: (row) => (row.expiresAt ? new Date(row.expiresAt).toLocaleString("fr-FR") : "—")
+    },
+    {
+      header: "Secrets requis",
+      accessor: (row) =>
+        row.requiredSecrets.length > 0 ? (
+          <ul className="space-y-1 text-xs text-slate-300">
+            {row.requiredSecrets.map((variable) => (
+              <li key={variable.name} className="flex items-center justify-between gap-2">
+                <code className="rounded bg-slate-900/60 px-1 py-0.5 text-[10px] text-slate-100">
+                  {variable.name}
+                </code>
+                <span className="text-[10px] text-slate-500">{variable.required ? "Obligatoire" : "Optionnel"}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <span className="text-xs text-slate-500">—</span>
+        )
+    },
+    {
+      header: "Documentation",
+      accessor: (row) =>
+        row.docsUrl ? (
+          <ResourceLink href={row.docsUrl} label="Guide" />
+        ) : (
+          <span className="text-xs text-slate-500">—</span>
+        )
+    }
+  ];
+
+  const columns: Column<McpIntegration>[] = [
+    {
+      header: "Plateforme",
+      accessor: (row) => (
+        <div className="space-y-1">
+          <p className="font-medium text-slate-100">{row.platform}</p>
+          <p className="text-xs text-slate-500">Transport {row.transport}</p>
+        </div>
+      )
+    },
+    {
+      header: "Serveur MCP",
+      accessor: (row) => <ResourceLink href={row.serverUrl} label={row.serverUrl} />
+    },
+    {
+      header: "Documentation",
+      accessor: (row) =>
+        row.docsUrl ? (
+          <ResourceLink href={row.docsUrl} label="Guide" />
+        ) : (
+          <span className="text-xs text-slate-500">—</span>
+        )
+    },
+    {
+      header: "Dernier check",
+      accessor: (row) => (row.updatedAt ? new Date(row.updatedAt).toLocaleString("fr-FR") : "—")
+    },
+    {
+      header: "Statut",
+      accessor: (row) => <StatusPill status={row.status} />
+    },
+    {
+      header: "Actions",
+      accessor: (row) => (
+        <form action={queueSync} className="flex justify-end">
+          <input type="hidden" name="provider" value={row.provider} />
+          <button
+            type="submit"
+            className="rounded-full border border-white/10 px-3 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-200 transition hover:border-accent-subtle"
+          >
+            Lancer une sync
+          </button>
+        </form>
+      )
+    }
+  ];
+
+  const syncColumns: Column<SyncJob>[] = [
+    { header: "Source", accessor: (row) => row.provider },
+    {
+      header: "Planifiée",
+      accessor: (row) => new Date(row.scheduledFor).toLocaleString("fr-FR")
+    },
+    {
+      header: "Démarrée",
+      accessor: (row) => (row.startedAt ? new Date(row.startedAt).toLocaleString("fr-FR") : "—")
+    },
+    {
+      header: "Terminée",
+      accessor: (row) => (row.finishedAt ? new Date(row.finishedAt).toLocaleString("fr-FR") : "—")
+    },
+    {
+      header: "Statut",
+      accessor: (row) => <Pill className={toneForSyncStatus(row.status)}>{row.status}</Pill>
+    }
+  ];
+
+  return (
+    <div className="space-y-10">
+      <SectionHeader
+        title="Administration"
+        description="Paramétrage connecteurs, quotas, guardrails"
+        action={
+          <a
+            href="https://modelcontextprotocol.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="rounded-full border border-white/10 px-4 py-2 text-xs text-slate-200 transition hover:border-accent-subtle"
+          >
+            Guide MCP officiel
+          </a>
+        }
+      />
+      <div className="space-y-4">
+        <SectionHeader
+          title="Paramètres API & secrets"
+          description="Etat des credentials chiffrés dans Supabase Vault"
+        />
+        {credentials.length === 0 ? (
+          <div className="glass-panel p-6 text-sm text-slate-400">
+            Aucun secret enregistré. Utilisez Supabase Vault (<code>supabase secrets set</code>) ou vos workflows IaC pour provisionner vos clés.
+          </div>
+        ) : (
+          <DataTable data={credentials} columns={credentialColumns} />
+        )}
+      </div>
+      {integrations.length === 0 ? (
+        <div className="glass-panel p-6 text-sm text-slate-400">
+          Aucun connecteur enregistré. Exécutez le script <code>npm run mcp:bootstrap</code> ou renseignez
+          <code className="mx-1 rounded bg-slate-900/60 px-1 py-0.5">mcp_connections</code> pour démarrer.
+        </div>
+      ) : (
+        <DataTable data={integrations} columns={columns} />
+      )}
+
+      <div className="space-y-4">
+        <SectionHeader
+          title="File de synchronisation"
+          description="Jobs Supabase → Dagster orchestrant les appels MCP et le rafraîchissement du semantic layer"
+        />
+        {syncQueue.length === 0 ? (
+          <div className="glass-panel p-6 text-sm text-slate-400">
+            Aucune synchronisation programmée. Déclenchez une sync depuis le tableau des connecteurs ou laissez Dagster gérer
+            les capteurs horaires.
+          </div>
+        ) : (
+          <DataTable data={syncQueue} columns={syncColumns} />
+        )}
+      </div>
+
+      <div className="glass-panel space-y-5 p-6">
+        <SectionHeader
+          title="Blueprint connecteurs MCP"
+          description="Endpoints recommandés, variables d'environnement et notes d'authentification"
+        />
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {mcpRegistry.map((entry) => (
+            <div key={entry.slug} className="rounded-2xl border border-white/10 bg-white/5 p-4 space-y-3">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="font-medium text-slate-100">{entry.label}</p>
+                  <p className="text-xs text-slate-500">Transports : {entry.transports.join(" · ")}</p>
+                </div>
+                {entry.docs ? <ResourceLink href={entry.docs} label="Doc" /> : null}
+              </div>
+
+              {entry.defaultServerUrl ? (
+                <p className="text-xs text-slate-400">
+                  Endpoint par défaut :
+                  <code className="ml-1 rounded bg-slate-900/60 px-1 py-0.5 text-[10px] text-slate-200">
+                    {entry.defaultServerUrl}
+                  </code>
+                </p>
+              ) : null}
+
+              {entry.env?.serverUrl ? (
+                <p className="text-xs text-slate-400">
+                  Variable URL :
+                  <code className="ml-1 rounded bg-slate-900/60 px-1 py-0.5 text-[10px] text-slate-200">
+                    {entry.env.serverUrl}
+                  </code>
+                </p>
+              ) : null}
+
+              {entry.env?.authHeader ? (
+                <p className="text-xs text-slate-400">
+                  Header auth :
+                  <code className="ml-1 rounded bg-slate-900/60 px-1 py-0.5 text-[10px] text-slate-200">
+                    {entry.env.authHeader}
+                  </code>
+                </p>
+              ) : null}
+
+              {entry.authVariables && entry.authVariables.length > 0 ? (
+                <div className="space-y-2">
+                  <p className="text-[10px] uppercase tracking-[0.3em] text-slate-500">Secrets requis</p>
+                  <ul className="space-y-1 text-xs text-slate-300">
+                    {entry.authVariables.map((variable) => (
+                      <li key={variable.name} className="space-y-0.5">
+                        <div className="flex items-center gap-2">
+                          <code className="rounded bg-slate-900/60 px-1 py-0.5 text-[10px] text-slate-100">
+                            {variable.name}
+                          </code>
+                          {variable.required ? (
+                            <Pill className="border-rose-400/40 bg-rose-400/10 text-rose-200">Obligatoire</Pill>
+                          ) : (
+                            <Pill className="border-slate-500/40 bg-slate-500/10 text-slate-200">Optionnel</Pill>
+                          )}
+                        </div>
+                        <p className="text-[11px] text-slate-500">{variable.description}</p>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+
+              {entry.notes && entry.notes.length > 0 ? (
+                <ul className="space-y-1 text-[11px] text-slate-500">
+                  {entry.notes.map((note) => (
+                    <li key={note}>• {note}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="glass-panel space-y-4 p-6">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">
+          Playbook d’intégration
+        </h3>
+        <ol className="space-y-3 text-sm text-slate-300">
+          <li className="flex gap-3">
+            <span className="text-accent-subtle">1.</span>
+            <span>
+              Provisionner les secrets OAuth dans Supabase Vault et déclarer les serveurs MCP côté OpenAI Agents avec
+              garde-fous (dry-run, seuils budget).
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="text-accent-subtle">2.</span>
+            <span>
+              Orchestrer les synchronisations horaires via Airflow/Composer et pousser les extraits normalisés vers le data
+              warehouse OrionPulse (tables fact_spend, fact_conv).
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="text-accent-subtle">3.</span>
+            <span>
+              Configurer les guardrails d’actions (approvals, fenêtres de gel) dans Supabase Policies et exposer les
+              endpoints Edge pour le Copilot GPT-5.
+            </span>
+          </li>
+        </ol>
+      </div>
+
+      <div className="glass-panel space-y-3 p-6">
+        <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">
+          Checklist backend
+        </h3>
+        <ul className="space-y-3 text-sm text-slate-300">
+          {backendChecks.map((item) => (
+            <li key={item.label} className="flex items-start justify-between gap-4 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+              <div>
+                <p className="font-medium text-slate-100">{item.label}</p>
+                <p className="text-xs text-slate-500">{item.description}</p>
+              </div>
+              <a
+                href={item.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-full border border-white/10 px-3 py-1 text-[10px] uppercase tracking-[0.3em] text-slate-200 hover:border-accent-subtle"
+              >
+                {item.status}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/alerts/page.tsx
+++ b/app/(dashboard)/alerts/page.tsx
@@ -1,0 +1,49 @@
+import { headers } from "next/headers";
+
+import { SectionHeader } from "@/components/ui/section-header";
+import { DataTable, type Column } from "@/components/ui/data-table";
+import { Pill } from "@/components/ui/pill";
+import { fetchAlertEvents } from "@/lib/data/alerts";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+
+type AlertRow = Awaited<ReturnType<typeof fetchAlertEvents>>[number];
+
+const columns: Column<AlertRow>[] = [
+  { header: "Règle", accessor: (row) => row.payload?.rule_name ?? row.ruleId },
+  {
+    header: "Impact",
+    accessor: (row) => row.payload?.impact ?? "—"
+  },
+  { header: "Statut", accessor: (row) => <Pill>{row.status}</Pill> },
+  {
+    header: "Déclenchée",
+    accessor: (row) => new Date(row.triggeredAt).toLocaleString("fr-FR")
+  }
+];
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+export default async function AlertsPage() {
+  const workspaceId = await loadWorkspaceId();
+  const events = await fetchAlertEvents(workspaceId);
+
+  return (
+    <div className="space-y-10">
+      <SectionHeader
+        title="Alerting & Runbooks"
+        description="Flux automatisés, intégrations Slack/Teams"
+      />
+      {events.length === 0 ? (
+        <div className="glass-panel p-6 text-sm text-slate-400">
+          Aucune alerte déclenchée. Configurez vos règles dans Supabase `alert_rules`.
+        </div>
+      ) : (
+        <DataTable data={events} columns={columns} />
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/anomalies/page.tsx
+++ b/app/(dashboard)/anomalies/page.tsx
@@ -1,0 +1,45 @@
+import { headers } from "next/headers";
+
+import { SectionHeader } from "@/components/ui/section-header";
+import { DataTable, type Column } from "@/components/ui/data-table";
+import { fetchAnomalies, type Anomaly } from "@/lib/data/anomalies";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+
+const columns: Column<Anomaly>[] = [
+  { header: "Type", accessor: (row) => row.dimension?.type ?? "Anomalie" },
+  { header: "Canal", accessor: (row) => row.dimension?.channel ?? "—" },
+  { header: "Territoire", accessor: (row) => row.dimension?.territory ?? "—" },
+  {
+    header: "Détectée",
+    accessor: (row) => new Date(row.detectedAt).toLocaleString("fr-FR")
+  },
+  { header: "Statut", accessor: (row) => row.status },
+  { header: "Runbook", accessor: (row) => row.description ?? "—" }
+];
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+export default async function AnomaliesPage() {
+  const workspaceId = await loadWorkspaceId();
+  const anomalies = await fetchAnomalies(workspaceId);
+
+  return (
+    <div className="space-y-10">
+      <SectionHeader
+        title="Détection d'anomalies"
+        description="Priorisation automatique et runbooks associés"
+      />
+      {anomalies.length === 0 ? (
+        <div className="glass-panel p-6 text-sm text-slate-400">
+          Pas d&apos;anomalies détectées. Les jobs Dagster alimentent la table `anomaly_events`.
+        </div>
+      ) : (
+        <DataTable data={anomalies} columns={columns} />
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/attribution/page.tsx
+++ b/app/(dashboard)/attribution/page.tsx
@@ -1,0 +1,60 @@
+import { headers } from "next/headers";
+
+import { SectionHeader } from "@/components/ui/section-header";
+import { Pill } from "@/components/ui/pill";
+import { fetchLiftTests } from "@/lib/data/attribution";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+export default async function AttributionPage() {
+  const workspaceId = await loadWorkspaceId();
+  const tests = await fetchLiftTests(workspaceId);
+
+  return (
+    <div className="space-y-10">
+      <SectionHeader
+        title="Attribution & Lift Lab"
+        description="Suivi des clean rooms, CAPI health et tests d'incrémentalité"
+      />
+
+      <div className="grid gap-6 xl:grid-cols-3">
+        {tests.length === 0 && (
+          <p className="col-span-full rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-400">
+            Aucun test en cours. Définissez vos expériences dans la table `lift_tests`.
+          </p>
+        )}
+        {tests.map((test) => (
+          <article key={test.id} className="glass-panel space-y-3 p-6">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-slate-100">{test.name}</h3>
+              <Pill>{test.platform ?? "N/A"}</Pill>
+            </div>
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-500">{test.status}</p>
+            <dl className="space-y-2 text-sm text-slate-300">
+              <div className="flex justify-between">
+                <dt>Début</dt>
+                <dd>{test.startDate ?? "—"}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Fin</dt>
+                <dd>{test.endDate ?? "—"}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt>Territoire</dt>
+                <dd>{test.territory ?? "—"}</dd>
+              </div>
+            </dl>
+            <button className="w-full rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-accent-subtle">
+              Ouvrir dans Clean Room
+            </button>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/copilot/page.tsx
+++ b/app/(dashboard)/copilot/page.tsx
@@ -1,0 +1,17 @@
+import { headers } from "next/headers";
+
+import { CopilotWorkspace } from "@/components/copilot/workspace";
+import { fetchCopilotSuggestions } from "@/lib/data/copilot";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+export default async function CopilotPage() {
+  const workspaceId = await loadWorkspaceId();
+  const suggestions = await fetchCopilotSuggestions(workspaceId);
+  return <CopilotWorkspace suggestions={suggestions} />;
+}

--- a/app/(dashboard)/creatives/page.tsx
+++ b/app/(dashboard)/creatives/page.tsx
@@ -1,0 +1,54 @@
+import { headers } from "next/headers";
+
+import { SectionHeader } from "@/components/ui/section-header";
+import { Pill } from "@/components/ui/pill";
+import { fetchCreativeAssets } from "@/lib/data/creatives";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+export default async function CreativesPage() {
+  const workspaceId = await loadWorkspaceId();
+  const assets = await fetchCreativeAssets(workspaceId);
+
+  return (
+    <div className="space-y-10">
+      <SectionHeader
+        title="Creative Intelligence"
+        description="Analyse CV/ASR, fatigue et recommandations"
+      />
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {assets.length === 0 && (
+          <p className="col-span-full rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-400">
+            Importez vos assets créatifs via les connecteurs MCP pour activer cette vue.
+          </p>
+        )}
+        {assets.map((creative) => (
+          <div key={creative.id} className="glass-panel overflow-hidden">
+            <div
+              className="h-40 w-full bg-cover bg-center"
+              style={{ backgroundImage: `url(${creative.thumbnailUrl ?? "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=400&q=80"})` }}
+            />
+            <div className="space-y-3 p-5">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold">{creative.name}</h3>
+                <Pill>{creative.status}</Pill>
+              </div>
+              <p className="text-sm text-slate-400">Plateforme : {creative.platform}</p>
+              <p className="text-sm text-slate-300">
+                Fatigue : {creative.fatigueScore?.toFixed(1) ?? "—"} · Tags : {creative.tags.join(", ") || "—"}
+              </p>
+              <button className="inline-flex items-center justify-center rounded-full border border-white/10 px-4 py-2 text-xs text-slate-200 hover:border-accent-subtle">
+                Générer brief GPT-5
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function DashboardRedirect() {
+  redirect("/overview");
+}

--- a/app/(dashboard)/governance/page.tsx
+++ b/app/(dashboard)/governance/page.tsx
@@ -1,0 +1,41 @@
+import { headers } from "next/headers";
+
+import { SectionHeader } from "@/components/ui/section-header";
+import { DataTable, type Column } from "@/components/ui/data-table";
+import { Pill } from "@/components/ui/pill";
+import { fetchGovernanceTasks, type GovernanceTask } from "@/lib/data/governance";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+
+const columns: Column<GovernanceTask>[] = [
+  { header: "Tâche", accessor: (row) => row.title },
+  { header: "Owner", accessor: (row) => row.owner },
+  { header: "Échéance", accessor: (row) => (row.due ? new Date(row.due).toLocaleString("fr-FR") : "—") },
+  { header: "Statut", accessor: (row) => <Pill>{row.status}</Pill> }
+];
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+export default async function GovernancePage() {
+  const workspaceId = await loadWorkspaceId();
+  const tasks = await fetchGovernanceTasks(workspaceId);
+
+  return (
+    <div className="space-y-10">
+      <SectionHeader
+        title="Gouvernance & Qualité"
+        description="Data contracts, SLA, conformité privacy-first"
+      />
+      {tasks.length === 0 ? (
+        <div className="glass-panel p-6 text-sm text-slate-400">
+          Aucune tâche détectée. Ajoutez des approvals ou des sync_jobs pour alimenter cette vue.
+        </div>
+      ) : (
+        <DataTable data={tasks} columns={columns} />
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/intelligence/page.tsx
+++ b/app/(dashboard)/intelligence/page.tsx
@@ -1,0 +1,48 @@
+import { headers } from "next/headers";
+
+import { SectionHeader } from "@/components/ui/section-header";
+import { Pill } from "@/components/ui/pill";
+import { fetchInsights } from "@/lib/data/insights";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+export default async function IntelligencePage() {
+  const workspaceId = await loadWorkspaceId();
+  const insights = await fetchInsights(workspaceId);
+
+  return (
+    <div className="space-y-10">
+      <SectionHeader
+        title="Intelligence augmentée"
+        description="Storytelling automatique & recommandations activables"
+      />
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        {insights.length === 0 && (
+          <p className="col-span-full rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-400">
+            Aucun récit disponible. Les conversations Copilot et modules IA alimentent la table `insights`.
+          </p>
+        )}
+        {insights.map((item) => (
+          <article key={item.id} className="glass-panel p-6 space-y-4">
+            <div className="flex flex-wrap items-center gap-2">
+              {item.territory && <Pill>{item.territory}</Pill>}
+              <Pill>{item.status}</Pill>
+              {item.impact != null && <Pill>Impact {item.impact.toFixed(1)}</Pill>}
+            </div>
+            <h3 className="text-xl font-semibold text-slate-100">{item.title}</h3>
+            <p className="text-sm text-slate-300">{item.body}</p>
+            <div className="rounded-2xl border border-emerald-400/30 bg-emerald-400/10 px-4 py-3 text-sm text-emerald-100">
+              {item.status === "approved" ? "Runbook validé" : "Soumettre au Copilot pour action"}
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from "react";
+import { Sidebar } from "@/components/navigation/sidebar";
+import { Topbar } from "@/components/navigation/topbar";
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-black text-slate-100">
+      <Sidebar />
+      <div className="flex-1 overflow-y-auto">
+        <Topbar />
+        <main className="px-10 py-12 space-y-12">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/opportunities/page.tsx
+++ b/app/(dashboard)/opportunities/page.tsx
@@ -1,0 +1,85 @@
+import { headers } from "next/headers";
+
+import { SectionHeader } from "@/components/ui/section-header";
+import { Pill } from "@/components/ui/pill";
+import { fetchOpportunities } from "@/lib/data/opportunities";
+import { fetchInsights } from "@/lib/data/insights";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+export default async function OpportunitiesPage() {
+  const workspaceId = await loadWorkspaceId();
+  const [opportunities, insights] = await Promise.all([
+    fetchOpportunities(workspaceId),
+    fetchInsights(workspaceId)
+  ]);
+
+  return (
+    <div className="space-y-10">
+      <SectionHeader
+        title="Opportunity pipeline"
+        description="Scoring automatisé des opportunités et récits générés par le copilot"
+      />
+
+      <div className="grid gap-6 xl:grid-cols-[1.4fr,1fr]">
+        <div className="glass-panel space-y-4 p-6">
+          <h3 className="text-sm uppercase tracking-[0.3em] text-slate-500">Backlog priorisé</h3>
+          <ul className="space-y-3 text-sm text-slate-200">
+            {opportunities.length === 0 && (
+              <li className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-slate-400">
+                Aucune opportunité détectée. Activez la surveillance dans l’onglet Intelligence.
+              </li>
+            )}
+            {opportunities.map((opportunity) => (
+              <li
+                key={opportunity.id}
+                className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="font-medium text-slate-100">{opportunity.title}</p>
+                    <p className="text-xs text-slate-400">
+                      Score {opportunity.score?.toFixed(1) ?? "—"} · {opportunity.territory ?? "—"} · ETA {opportunity.eta ?? "—"}
+                    </p>
+                  </div>
+                  <Pill>{opportunity.status}</Pill>
+                </div>
+                {opportunity.summary && (
+                  <p className="mt-2 text-xs text-slate-400">{opportunity.summary}</p>
+                )}
+                <p className="mt-2 text-xs text-slate-500">Owner : {opportunity.ownerName ?? "Non assigné"}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className="glass-panel space-y-4 p-6">
+          <h3 className="text-sm uppercase tracking-[0.3em] text-slate-500">Récits Copilot</h3>
+          <ul className="space-y-4">
+            {insights.length === 0 && (
+              <li className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-400">
+                Aucun récit enregistré. Les conversations Copilot alimentent automatiquement cette section.
+              </li>
+            )}
+            {insights.map((narrative) => (
+              <li key={narrative.id} className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200">
+                <div className="flex flex-wrap gap-2">
+                  {narrative.territory && <Pill>{narrative.territory}</Pill>}
+                  {narrative.impact != null && <Pill>Impact {narrative.impact.toFixed(1)}</Pill>}
+                  <Pill>{narrative.status}</Pill>
+                </div>
+                <p className="font-medium text-slate-100">{narrative.title}</p>
+                <p className="text-slate-400">{narrative.body}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/overview/page.tsx
+++ b/app/(dashboard)/overview/page.tsx
@@ -1,0 +1,149 @@
+import { MetricCard } from "@/components/cards/metric-card";
+import { TerritoryChart } from "@/components/charts/territory-chart";
+import { SectionHeader } from "@/components/ui/section-header";
+import { Pill } from "@/components/ui/pill";
+import { headers } from "next/headers";
+
+import {
+  fetchActiveAlerts,
+  fetchKpiSummary,
+  fetchSyncStatus,
+  fetchTerritoryPerformance
+} from "@/lib/data/overview";
+import { fetchMcpIntegrations, integrationStatusTone } from "@/lib/data/integrations";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+import { AlertTriangle, Download } from "lucide-react";
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+export default async function OverviewPage() {
+  const workspaceId = await loadWorkspaceId();
+
+  const [kpiSummary, territoryBreakdown, syncStatus, activeAlerts, integrations] = await Promise.all([
+    fetchKpiSummary(workspaceId),
+    fetchTerritoryPerformance(workspaceId),
+    fetchSyncStatus(workspaceId),
+    fetchActiveAlerts(workspaceId),
+    fetchMcpIntegrations(workspaceId)
+  ]);
+
+  return (
+    <div className="space-y-12">
+      <SectionHeader
+        title="Overview MQ · GP · GF"
+        description="Vue consolidée des KPIs, synchronisations MCP et alertes prioritaires"
+        action={
+          <button className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-accent-subtle">
+            <Download className="h-4 w-4" />
+            Exporter le snapshot
+          </button>
+        }
+      />
+
+      <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+        {kpiSummary.length === 0 ? (
+          <p className="col-span-full rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-400">
+            Aucune donnée disponible pour le workspace. Lancez une synchronisation MCP pour alimenter les KPIs.
+          </p>
+        ) : (
+          kpiSummary.map((kpi) => (
+            <MetricCard key={kpi.label} label={kpi.label} value={kpi.value} delta={kpi.delta ?? undefined} />
+          ))
+        )}
+      </div>
+
+      <div className="grid gap-6 2xl:grid-cols-[2fr,1.2fr]">
+        {territoryBreakdown.length === 0 ? (
+          <div className="glass-panel flex h-80 items-center justify-center p-6 text-sm text-slate-400">
+            Aucune donnée territoriale pour l’instant.
+          </div>
+        ) : (
+          <TerritoryChart data={territoryBreakdown} />
+        )}
+
+        <div className="glass-panel space-y-5 p-6">
+          <SectionHeader title="Synchronisations" description="Orchestration Dagster & MCP" />
+          <ul className="space-y-3 text-sm">
+            {syncStatus.length === 0 && (
+              <li className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-slate-400">
+                Aucune synchronisation enregistrée.
+              </li>
+            )}
+            {syncStatus.map((item) => (
+              <li key={`${item.provider}-${item.status}`} className="flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-4 py-3">
+                <div>
+                  <p className="font-medium text-slate-100">{item.provider}</p>
+                  <p className="text-xs text-slate-400">
+                    Dernière exécution {item.lastRun ?? "—"} · prochaine {item.nextRun ?? "—"}
+                  </p>
+                </div>
+                <Pill className="border-accent/40 bg-accent/10 text-accent-subtle">{item.status}</Pill>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <div className="glass-panel p-6 space-y-4">
+          <SectionHeader title="Alertes actives" description="Guardrails & playbooks" />
+          <div className="space-y-4">
+            {activeAlerts.length === 0 && (
+              <p className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-400">
+                Aucune alerte en cours. Configurez vos règles dans l’onglet Alertes.
+              </p>
+            )}
+            {activeAlerts.map((alert) => (
+              <div key={alert.id} className="rounded-2xl border border-amber-300/20 bg-amber-300/5 p-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <p className="font-medium text-amber-200">{alert.title}</p>
+                    <p className="text-sm text-amber-100/80">{alert.runbook ?? "Consultez le runbook associé."}</p>
+                  </div>
+                  <Pill className="text-amber-100 border-amber-200/30 bg-amber-200/10">{alert.status}</Pill>
+                </div>
+                {alert.impact && (
+                  <p className="mt-2 text-xs text-amber-100/80 uppercase tracking-[0.3em]">
+                    Impact : {alert.impact}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+          <p className="flex items-center gap-2 text-xs text-slate-400">
+            <AlertTriangle className="h-4 w-4" />
+            Les actions nécessitent validation Admin ou Copilot.
+          </p>
+        </div>
+
+        <div className="glass-panel p-6 space-y-4">
+          <SectionHeader title="Connecteurs MCP" description="Etat des serveurs distants" />
+          <ul className="space-y-3 text-sm">
+            {integrations.length === 0 && (
+              <li className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-slate-400">
+                Aucun connecteur enregistré. Ajoutez vos serveurs dans Admin → Integrations.
+              </li>
+            )}
+            {integrations.map((integration) => (
+              <li key={integration.id} className="flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-4 py-3">
+                <div>
+                  <p className="font-medium text-slate-100">{integration.platform}</p>
+                  <p className="text-xs text-slate-400">
+                    Transport {integration.transport} · dernière santé {integration.updatedAt ? new Date(integration.updatedAt).toLocaleString("fr-FR") : "—"}
+                  </p>
+                </div>
+                <span className={`rounded-full border px-3 py-1 text-[10px] uppercase tracking-[0.3em] ${integrationStatusTone[integration.status]}`}>
+                  {integration.status}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/performance/page.tsx
+++ b/app/(dashboard)/performance/page.tsx
@@ -1,0 +1,65 @@
+import { headers } from "next/headers";
+
+import { SectionHeader } from "@/components/ui/section-header";
+import { DataTable, type Column } from "@/components/ui/data-table";
+import { Pill } from "@/components/ui/pill";
+import { fetchPerformanceRows, type PerformanceRow } from "@/lib/data/performance";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+
+const columns: Column<PerformanceRow>[] = [
+  { header: "Canal", accessor: (row) => row.platform },
+  { header: "Territoire", accessor: (row) => (row.territory ? <Pill>{row.territory}</Pill> : "—") },
+  {
+    header: "Spend",
+    accessor: (row) => `€${row.spend.toLocaleString("fr-FR")}`
+  },
+  { header: "Impr.", accessor: (row) => row.impressions.toLocaleString("fr-FR") },
+  { header: "Clicks", accessor: (row) => row.clicks.toLocaleString("fr-FR") },
+  { header: "Conv.", accessor: (row) => row.conversions.toLocaleString("fr-FR") },
+  {
+    header: "CPA",
+    accessor: (row) => (row.cpa == null ? "—" : `€${row.cpa.toFixed(2)}`)
+  },
+  {
+    header: "ROAS",
+    accessor: (row) => (row.roas == null ? "—" : <span className="font-medium text-emerald-300">{row.roas.toFixed(1)}x</span>)
+  }
+];
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+export default async function PerformancePage() {
+  const workspaceId = await loadWorkspaceId();
+  const data = await fetchPerformanceRows(workspaceId, {});
+
+  return (
+    <div className="space-y-10">
+      <SectionHeader
+        title="Performance cross-canal"
+        description="Pivot campagnes/adsets/ads alimenté par le semantic layer"
+      />
+
+      <div className="glass-panel space-y-4 p-6 text-sm text-slate-300">
+        <p>
+          Les métriques sont requêtées en direct depuis la vue `v_kpi_daily`. Les exports massifs peuvent être déclenchés via
+          tRPC `performance.export`.
+        </p>
+        <p className="text-xs text-slate-500">
+          Les filtres avancés (territoire, plateforme, période) seront branchés côté client sur les paramètres d’URL.
+        </p>
+      </div>
+
+      {data.length === 0 ? (
+        <div className="glass-panel p-6 text-sm text-slate-400">
+          Aucun enregistrement. Ajoutez des lignes dans `performance_daily` via vos pipelines MCP.
+        </div>
+      ) : (
+        <DataTable data={data} columns={columns} />
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/planner/page.tsx
+++ b/app/(dashboard)/planner/page.tsx
@@ -1,0 +1,50 @@
+import { headers } from "next/headers";
+
+import { SectionHeader } from "@/components/ui/section-header";
+import { Pill } from "@/components/ui/pill";
+import { fetchPlannerScenarios } from "@/lib/data/planner";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+export default async function PlannerPage() {
+  const workspaceId = await loadWorkspaceId();
+  const scenarios = await fetchPlannerScenarios(workspaceId);
+
+  return (
+    <div className="space-y-10">
+      <SectionHeader
+        title="What-if Planner"
+        description="Simulations MMM hybrides & allocation assistée"
+        action={<Pill className="border-accent/40 bg-accent/10 text-accent">Modèle actualisé 2h</Pill>}
+      />
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        {scenarios.length === 0 && (
+          <p className="col-span-full rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-400">
+            Aucun scénario enregistré. Créez vos plans dans la table `planner_scenarios`.
+          </p>
+        )}
+        {scenarios.map((scenario) => (
+          <div key={scenario.id} className="glass-panel p-6 space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-xl font-semibold text-slate-100">{scenario.name}</h3>
+              <Pill>{scenario.status}</Pill>
+            </div>
+            <p className="text-sm text-slate-400">
+              Objectif : {JSON.stringify(scenario.objective)}
+            </p>
+            <p className="text-sm text-emerald-300">Hypothèses : {JSON.stringify(scenario.assumptions)}</p>
+            <button className="mt-4 inline-flex items-center justify-center rounded-full border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-accent-subtle">
+              Envoyer au copilot pour simulation
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -1,0 +1,77 @@
+import { headers } from "next/headers";
+
+import { SectionHeader } from "@/components/ui/section-header";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+async function fetchProfile(workspaceId: string) {
+  const supabase = createServiceRoleClient();
+  const { data: membership } = await supabase
+    .from("memberships")
+    .select("user_id,role,territories,users(full_name,email)")
+    .eq("workspace_id", workspaceId)
+    .limit(1)
+    .single();
+
+  return membership;
+}
+
+export default async function ProfilePage() {
+  const workspaceId = await loadWorkspaceId();
+  const membership = await fetchProfile(workspaceId);
+
+  const preferences = [
+    {
+      id: "pref-1",
+      label: "Langue du copilot",
+      value: "Français",
+      description: "Langue principale pour les réponses générées"
+    },
+    {
+      id: "pref-2",
+      label: "Canal d'alerting",
+      value: process.env.DEFAULT_ALERT_CHANNEL ?? "Non configuré",
+      description: "Destination des alertes critiques"
+    },
+    {
+      id: "pref-3",
+      label: "Fenêtres de gel",
+      value: process.env.CHANGE_FREEZE_WINDOW ?? "Non défini",
+      description: "Créneaux où aucune action automatique n'est exécutée"
+    }
+  ];
+
+  return (
+    <div className="space-y-10">
+      <SectionHeader
+        title="Profil & Préférences"
+        description="Personnalisation de l'expérience OrionPulse"
+      />
+
+      <div className="glass-panel divide-y divide-white/5">
+        <div className="space-y-1 px-6 py-5">
+          <p className="text-sm font-semibold text-slate-200">Utilisateur</p>
+          <p className="text-sm text-accent">{membership?.users?.full_name ?? "Utilisateur inconnu"}</p>
+          <p className="text-xs text-slate-500">{membership?.users?.email ?? "Email non défini"}</p>
+        </div>
+        <div className="space-y-1 px-6 py-5">
+          <p className="text-sm font-semibold text-slate-200">Rôle</p>
+          <p className="text-sm text-accent">{membership?.role ?? "Non défini"}</p>
+          <p className="text-xs text-slate-500">Territoires : {(membership?.territories ?? []).join(", ") || "Tous"}</p>
+        </div>
+        {preferences.map((preference) => (
+          <div key={preference.id} className="space-y-1 px-6 py-5">
+            <p className="text-sm font-semibold text-slate-200">{preference.label}</p>
+            <p className="text-sm text-accent">{preference.value}</p>
+            <p className="text-xs text-slate-500">{preference.description}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/reports/page.tsx
+++ b/app/(dashboard)/reports/page.tsx
@@ -1,0 +1,80 @@
+import { headers } from "next/headers";
+
+import { SectionHeader } from "@/components/ui/section-header";
+import { fetchReports, fetchExports } from "@/lib/data/reports";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+import { Download, FileText } from "lucide-react";
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+export default async function ReportsPage() {
+  const workspaceId = await loadWorkspaceId();
+  const [reports, exportsHistory] = await Promise.all([
+    fetchReports(workspaceId),
+    fetchExports(workspaceId)
+  ]);
+
+  return (
+    <div className="space-y-10">
+      <SectionHeader
+        title="Report builder & library"
+        description="Templates white-label, planification et signature"
+        action={
+          <button className="inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-accent-subtle">
+            <FileText className="h-4 w-4" />
+            Nouveau template
+          </button>
+        }
+      />
+
+      <div className="grid gap-6 xl:grid-cols-3">
+        {reports.length === 0 && (
+          <p className="col-span-full rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-400">
+            Aucun template configuré. Insérez des lignes dans la table `reports` pour les rendre disponibles.
+          </p>
+        )}
+        {reports.map((report) => (
+          <article key={report.id} className="glass-panel space-y-4 p-6">
+            <div className="flex items-center justify-between text-sm text-slate-400">
+              <span className="uppercase tracking-[0.3em]">PDF</span>
+              <span>{report.cadence ?? "à la demande"}</span>
+            </div>
+            <h3 className="text-xl font-semibold text-slate-100">{report.name}</h3>
+            <p className="text-sm text-slate-400">{report.recipients.length} destinataires</p>
+            <div className="flex gap-3">
+              <button className="flex-1 rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-accent-subtle">
+                Paramétrer
+              </button>
+              <button className="rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-accent-subtle">
+                <Download className="h-4 w-4" />
+              </button>
+            </div>
+          </article>
+        ))}
+      </div>
+
+      <div className="glass-panel space-y-3 p-6">
+        <h3 className="text-sm uppercase tracking-[0.3em] text-slate-500">Exports récents</h3>
+        <ul className="space-y-2 text-sm text-slate-300">
+          {exportsHistory.length === 0 && (
+            <li className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-slate-400">
+              Aucun export lancé.
+            </li>
+          )}
+          {exportsHistory.map((exportJob) => (
+            <li key={exportJob.id} className="flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-4 py-3">
+              <span>
+                {exportJob.reportName} · {new Date(exportJob.createdAt).toLocaleString("fr-FR")}
+              </span>
+              <span className="text-xs uppercase tracking-[0.3em] text-slate-500">{exportJob.status}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/territories/page.tsx
+++ b/app/(dashboard)/territories/page.tsx
@@ -1,0 +1,101 @@
+import { headers } from "next/headers";
+
+import { SectionHeader } from "@/components/ui/section-header";
+import { Pill } from "@/components/ui/pill";
+import { fetchActiveAlerts } from "@/lib/data/overview";
+import { fetchTerritorySnapshots } from "@/lib/data/territories";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+import { AlertTriangle } from "lucide-react";
+
+const healthTone: Record<string, string> = {
+  OK: "border-emerald-400/30 bg-emerald-400/10 text-emerald-100",
+  Warning: "border-amber-400/30 bg-amber-400/10 text-amber-100"
+};
+
+function computeHealth(lastObservedAt?: string | null) {
+  if (!lastObservedAt) {
+    return "Warning" as const;
+  }
+  const last = new Date(lastObservedAt);
+  const hours = (Date.now() - last.getTime()) / 1000 / 3600;
+  return hours > 36 ? ("Warning" as const) : ("OK" as const);
+}
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+export default async function TerritoriesPage() {
+  const workspaceId = await loadWorkspaceId();
+  const [territories, alerts] = await Promise.all([
+    fetchTerritorySnapshots(workspaceId),
+    fetchActiveAlerts(workspaceId)
+  ]);
+
+  return (
+    <div className="space-y-10">
+      <SectionHeader
+        title="Territory command center"
+        description="Suivi MQ · GP · GF avec santé des flux, saturation média et alertes locales"
+      />
+
+      <div className="grid gap-6 xl:grid-cols-3">
+        {territories.length === 0 && (
+          <p className="col-span-full rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-400">
+            Renseignez les territoires dans vos imports MCP pour alimenter cette vue.
+          </p>
+        )}
+        {territories.map((territory) => {
+          const health = computeHealth(territory.lastObservedAt);
+          return (
+            <div key={territory.territory} className="glass-panel space-y-4 p-6">
+              <div className="flex items-center justify-between">
+                <h3 className="text-xl font-semibold text-slate-100">{territory.territory}</h3>
+                <Pill className={healthTone[health]}>{health}</Pill>
+              </div>
+              <dl className="space-y-2 text-sm text-slate-300">
+                <div className="flex justify-between">
+                  <dt>Investissement</dt>
+                  <dd className="font-medium text-slate-100">€{territory.spend.toLocaleString("fr-FR")}</dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt>ROAS</dt>
+                  <dd className="font-medium text-emerald-300">{territory.roas?.toFixed(1) ?? "—"}x</dd>
+                </div>
+                <div className="flex justify-between">
+                  <dt>Fraîcheur</dt>
+                  <dd>{territory.lastObservedAt ? new Date(territory.lastObservedAt).toLocaleString("fr-FR") : "—"}</dd>
+                </div>
+              </dl>
+              <button className="w-full rounded-xl border border-white/10 px-4 py-2 text-sm text-slate-200 hover:border-accent-subtle">
+                Ouvrir la checklist runbook
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="glass-panel space-y-3 p-6">
+        <div className="flex items-center gap-3 text-amber-200">
+          <AlertTriangle className="h-4 w-4" />
+          <p className="text-sm font-medium">Alertes territoriales en cours</p>
+        </div>
+        <ul className="space-y-2 text-sm text-slate-200">
+          {alerts.length === 0 && (
+            <li className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-slate-400">
+              Aucune alerte ouverte.
+            </li>
+          )}
+          {alerts.map((alert) => (
+            <li key={alert.id} className="flex items-center justify-between rounded-xl border border-amber-300/20 bg-amber-300/5 px-4 py-3">
+              <span>{alert.title}</span>
+              <span className="text-xs uppercase tracking-[0.3em] text-amber-100">{alert.status}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/app/api/copilot/route.ts
+++ b/app/api/copilot/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import {
+  appendEvent,
+  persistCopilotEvent,
+  type CopilotSession
+} from "@/lib/ai/copilot";
+import { invokeCopilotAgent } from "@/lib/ai/openai-agent";
+
+const messageSchema = z.object({
+  role: z.enum(["user", "assistant", "system", "tool"]),
+  content: z.string(),
+  createdAt: z.string().optional()
+});
+
+const sessionSchema = z.object({
+  id: z.string().uuid(),
+  workspaceId: z.string().uuid().optional(),
+  territory: z.string().optional(),
+  events: z.array(messageSchema)
+});
+
+const requestSchema = z.object({
+  session: sessionSchema,
+  prompt: z.string().min(1, "Une requête est nécessaire")
+});
+
+function parseSession(payload: z.infer<typeof sessionSchema>): CopilotSession {
+  return {
+    id: payload.id,
+    workspaceId: payload.workspaceId,
+    territory: payload.territory,
+    events: payload.events.map((event) => ({
+      role: event.role,
+      content: event.content,
+      createdAt: event.createdAt ? new Date(event.createdAt) : new Date()
+    }))
+  };
+}
+
+export async function POST(request: Request) {
+  try {
+    const json = await request.json();
+    const parsed = requestSchema.parse(json);
+    const session = parseSession(parsed.session);
+
+    const withUserEvent = appendEvent(session, {
+      role: "user",
+      content: parsed.prompt
+    });
+
+    const lastUserEvent = withUserEvent.events.at(-1);
+    if (lastUserEvent) {
+      await persistCopilotEvent(withUserEvent, lastUserEvent);
+    }
+
+    const agentAnswer = await invokeCopilotAgent(
+      withUserEvent.events.slice(-10).map((event) => ({
+        role: event.role,
+        content: event.content
+      })),
+      session.workspaceId
+    );
+
+    const assistantEvent = {
+      role: "assistant" as const,
+      content: agentAnswer,
+      createdAt: new Date()
+    };
+
+    const finalSession = appendEvent(withUserEvent, assistantEvent);
+    await persistCopilotEvent(finalSession, assistantEvent);
+
+    return NextResponse.json({
+      event: assistantEvent,
+      session: {
+        ...finalSession,
+        events: finalSession.events.map((event) => ({
+          ...event,
+          createdAt: event.createdAt?.toISOString()
+        }))
+      }
+    });
+  } catch (error) {
+    console.error("Copilot error", error);
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Requête invalide", details: error.flatten() },
+        { status: 422 }
+      );
+    }
+    return NextResponse.json(
+      { error: "Impossible de traiter la requête Copilot" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/trpc/[trpc]/route.ts
+++ b/app/api/trpc/[trpc]/route.ts
@@ -1,0 +1,13 @@
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { appRouter } from "@/server/api/root";
+import { createContext } from "@/server/api/trpc";
+
+const handler = (request: Request) =>
+  fetchRequestHandler({
+    endpoint: "/api/trpc",
+    req: request,
+    router: appRouter,
+    createContext: () => createContext({ req: request })
+  });
+
+export { handler as GET, handler as POST };

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+
+export default function SignInPage() {
+  return (
+    <div className="mx-auto flex min-h-screen max-w-lg flex-col justify-center px-6 py-16">
+      <div className="glass-panel p-10 space-y-6">
+        <div>
+          <p className="text-xs uppercase tracking-[0.4em] text-slate-400">Connexion sécurisée</p>
+          <h1 className="text-3xl font-semibold text-slate-100">Accéder à OrionPulse</h1>
+          <p className="text-sm text-slate-400">
+            Authentification via Supabase + SSO interne. Utilisez vos identifiants MQ/GP/GF.
+          </p>
+        </div>
+        <form className="space-y-4">
+          <label className="block text-sm">
+            <span className="text-slate-300">Email professionnel</span>
+            <input
+              type="email"
+              placeholder="prenom.nom@domaine.com"
+              className="mt-2 w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-slate-100 outline-none focus:border-accent"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-slate-300">Mot de passe</span>
+            <input
+              type="password"
+              placeholder="••••••••"
+              className="mt-2 w-full rounded-xl border border-white/10 bg-black/40 px-4 py-3 text-sm text-slate-100 outline-none focus:border-accent"
+            />
+          </label>
+          <button
+            type="submit"
+            className="w-full rounded-xl bg-accent px-4 py-3 text-sm font-semibold text-slate-900 hover:bg-accent-muted"
+          >
+            Se connecter
+          </button>
+        </form>
+        <p className="text-xs text-slate-500">
+          SSO requis ? <Link href="/auth/sso" className="text-accent">Initier la connexion</Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/auth/sso/page.tsx
+++ b/app/auth/sso/page.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+export default function SSOPage() {
+  return (
+    <div className="mx-auto flex min-h-screen max-w-xl flex-col justify-center px-6 py-16">
+      <div className="glass-panel space-y-6 p-10">
+        <h1 className="text-3xl font-semibold text-slate-100">Connexion SSO OrionPulse</h1>
+        <p className="text-sm text-slate-400">
+          Redirection vers le fournisseur SAML/SCIM interne. Vérifiez que vous êtes connecté au VPN MQ/GP/GF avant de poursuivre.
+        </p>
+        <button className="w-full rounded-xl bg-accent px-4 py-3 text-sm font-semibold text-slate-900 hover:bg-accent-muted">
+          Continuer vers l’IdP
+        </button>
+        <p className="text-xs text-slate-500">
+          Besoin d’aide ? Consultez la <Link href="/governance" className="text-accent">documentation sécurité</Link> ou contactez ops@orionpulse.dom.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,39 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-background text-slate-100 font-sans min-h-screen;
+}
+
+a {
+  @apply text-accent transition-colors duration-150;
+}
+
+a:hover {
+  @apply text-accent-subtle;
+}
+
+.glass-panel {
+  @apply bg-surface/80 backdrop-blur-xl border border-white/10 rounded-2xl shadow-glass;
+}
+
+.gradient-border {
+  position: relative;
+}
+
+.gradient-border::before {
+  content: "";
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(135deg, rgba(92, 124, 250, 0.8), rgba(23, 213, 255, 0.4));
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "OrionPulse",
+  description: "Marketing intelligence copilot for MQ/GP/GF territories"
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <main className="min-h-screen bg-gradient-to-br from-[#010308] via-[#030A1A] to-[#0B1733]">
+          {children}
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+
+export default function HomePage() {
+  return (
+    <section className="px-8 py-24 mx-auto max-w-6xl text-slate-100">
+      <div className="glass-panel gradient-border p-12">
+        <p className="uppercase tracking-[0.4em] text-xs text-accent-subtle mb-6">
+          OrionPulse • Internal SaaS
+        </p>
+        <h1 className="text-5xl font-semibold leading-tight mb-6">
+          Orchestration marketing augmentée pour MQ · GP · GF
+        </h1>
+        <p className="text-lg text-slate-300 max-w-3xl">
+          Connectez vos sources publicitaires via MCP, harmonisez les indicateurs MQ/GP/GF et pilotez vos budgets avec le copilot GPT-5 intégré. OrionPulse réunit dashboards, alerting et runbooks opérables dans une expérience unifiée.
+        </p>
+        <div className="mt-10 flex flex-wrap gap-4">
+          <Link
+            href="/overview"
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-accent text-slate-900 font-semibold hover:bg-accent-muted transition"
+          >
+            Ouvrir le control center
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+          <Link
+            href="/admin"
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-full border border-white/20 text-slate-100 hover:border-accent-subtle transition"
+          >
+            Configurer la plateforme
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/cards/metric-card.tsx
+++ b/components/cards/metric-card.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from "react";
+
+export function MetricCard({ label, value, delta, icon }: { label: string; value: string; delta: string; icon?: ReactNode }) {
+  return (
+    <div className="glass-panel p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm uppercase tracking-[0.2em] text-slate-400">{label}</p>
+        {icon}
+      </div>
+      <p className="text-3xl font-semibold">{value}</p>
+      <p className="text-sm text-emerald-400">{delta}</p>
+    </div>
+  );
+}

--- a/components/charts/territory-chart.tsx
+++ b/components/charts/territory-chart.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useMemo } from "react";
+import ReactEChartsCore from "echarts-for-react/lib/core";
+import type { EChartsOption } from "echarts";
+import * as echarts from "echarts/core";
+import { BarChart, LineChart } from "echarts/charts";
+import {
+  DatasetComponent,
+  GridComponent,
+  LegendComponent,
+  TooltipComponent
+} from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+
+echarts.use([BarChart, LineChart, DatasetComponent, GridComponent, LegendComponent, TooltipComponent, CanvasRenderer]);
+
+export type TerritoryDatum = {
+  territory: string;
+  spend: number;
+  roas: number | null;
+};
+
+export function TerritoryChart({ data }: { data: TerritoryDatum[] }) {
+  const option = useMemo<EChartsOption>(() => {
+    return {
+      backgroundColor: "transparent",
+      animationDuration: 600,
+      dataset: {
+        dimensions: ["territory", "spend", "roas"],
+        source: data.map((item) => ({
+          territory: item.territory,
+          spend: Number(item.spend ?? 0),
+          roas: item.roas == null ? null : Number(item.roas)
+        }))
+      },
+      grid: { top: 40, left: 48, right: 48, bottom: 32, containLabel: true },
+      legend: {
+        textStyle: { color: "#cbd5f5", fontSize: 12 }
+      },
+      tooltip: {
+        trigger: "axis",
+        axisPointer: { type: "shadow" },
+        backgroundColor: "rgba(12, 22, 38, 0.92)",
+        borderColor: "rgba(148, 163, 184, 0.2)",
+        textStyle: { color: "#e2e8f0", fontSize: 12 },
+        valueFormatter: (value, series) => {
+          if (series?.seriesName === "ROAS" && typeof value === "number") {
+            return `${value.toFixed(2)}x`;
+          }
+          if (typeof value === "number") {
+            return `€${value.toLocaleString("fr-FR")}`;
+          }
+          return value as string;
+        }
+      },
+      xAxis: {
+        type: "category",
+        axisLabel: { color: "#cbd5f5" },
+        axisLine: { lineStyle: { color: "rgba(148, 163, 184, 0.2)" } }
+      },
+      yAxis: [
+        {
+          type: "value",
+          axisLabel: {
+            color: "#cbd5f5",
+            formatter: (value: number) => `€${(value / 1000).toFixed(0)}k`
+          },
+          splitLine: { lineStyle: { color: "rgba(148, 163, 184, 0.08)" } }
+        },
+        {
+          type: "value",
+          axisLabel: {
+            color: "#cbd5f5",
+            formatter: (value: number) => `${value.toFixed(1)}x`
+          },
+          splitLine: { show: false }
+        }
+      ],
+      series: [
+        {
+          type: "bar",
+          name: "Investissement",
+          encode: { x: "territory", y: "spend" },
+          itemStyle: {
+            borderRadius: [12, 12, 4, 4],
+            color: {
+              type: "linear",
+              x: 0,
+              y: 0,
+              x2: 0,
+              y2: 1,
+              colorStops: [
+                { offset: 0, color: "#5C7CFA" },
+                { offset: 1, color: "rgba(92, 124, 250, 0.15)" }
+              ]
+            }
+          }
+        },
+        {
+          type: "line",
+          name: "ROAS",
+          encode: { x: "territory", y: "roas" },
+          yAxisIndex: 1,
+          smooth: true,
+          symbol: "circle",
+          symbolSize: 10,
+          lineStyle: { width: 3, color: "#4ade80" },
+          itemStyle: { color: "#4ade80", borderColor: "#0f172a", borderWidth: 2 }
+        }
+      ]
+    } satisfies EChartsOption;
+  }, [data]);
+
+  return (
+    <div className="glass-panel h-80 p-6">
+      <ReactEChartsCore echarts={echarts} option={option} style={{ height: "100%", width: "100%" }} notMerge lazyUpdate />
+    </div>
+  );
+}

--- a/components/copilot/workspace.tsx
+++ b/components/copilot/workspace.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { Bot, Loader2, Mic, Paperclip, Send, User } from "lucide-react";
+
+import { SectionHeader } from "@/components/ui/section-header";
+import { appendEvent, serializeForAgent, type CopilotSession } from "@/lib/ai/copilot";
+
+type ConversationEvent = CopilotSession["events"][number];
+
+function generateSessionId() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (char) => {
+    const random = (Math.random() * 16) | 0;
+    const value = char === "x" ? random : (random & 0x3) | 0x8;
+    return value.toString(16);
+  });
+}
+
+function createInitialSession(): CopilotSession {
+  const sessionId = generateSessionId();
+  return {
+    id: sessionId,
+    events: [
+      {
+        role: "assistant",
+        content:
+          "Bonjour 👋 Je suis le Copilot OrionPulse. Demandez-moi une analyse MQ/GP/GF ou sollicitez un runbook MCP.",
+        createdAt: new Date()
+      }
+    ]
+  };
+}
+
+function formatTimestamp(event: ConversationEvent) {
+  return event.createdAt?.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" }) ?? "";
+}
+
+export function CopilotWorkspace({ suggestions }: { suggestions: string[] }) {
+  const [session, setSession] = useState<CopilotSession>(() => createInitialSession());
+  const [input, setInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+  const agentPreview = useMemo(() => serializeForAgent(session), [session]);
+
+  async function handleSubmit(prompt: string) {
+    if (isPending) return;
+    if (!prompt.trim()) return;
+    const nextSession = appendEvent(session, { role: "user", content: prompt });
+    setSession(nextSession);
+    setInput("");
+    setError(null);
+
+    startTransition(async () => {
+      try {
+        const response = await fetch("/api/copilot", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            prompt,
+            session: {
+              ...nextSession,
+              events: nextSession.events.map((event) => ({
+                role: event.role,
+                content: event.content,
+                createdAt: event.createdAt?.toISOString()
+              }))
+            }
+          })
+        });
+
+        if (!response.ok) {
+          throw new Error("Réponse inattendue de l'API Copilot");
+        }
+
+        const data = (await response.json()) as {
+          event: ConversationEvent;
+          session: CopilotSession & {
+            events: (ConversationEvent & { createdAt?: string | Date })[];
+          };
+        };
+
+        setSession({
+          ...data.session,
+          events: data.session.events.map((event) => ({
+            ...event,
+            createdAt: event.createdAt ? new Date(event.createdAt) : new Date()
+          }))
+        });
+      } catch (apiError) {
+        console.error(apiError);
+        const fallbackSession = appendEvent(nextSession, {
+          role: "assistant",
+          content:
+            "Je n'ai pas pu contacter l'agent GPT-5. Vérifiez la configuration OPENAI_API_KEY ou réessayez plus tard.",
+          createdAt: new Date()
+        });
+        setError("Le Copilot n'a pas répondu");
+        setSession(fallbackSession);
+      }
+    });
+  }
+
+  return (
+    <div className="space-y-10">
+      <SectionHeader
+        title="Copilot GPT-5"
+        description="Agent MCP-aware connecté aux données OrionPulse"
+      />
+
+      <div className="grid gap-6 xl:grid-cols-[2fr,1fr]">
+        <div className="glass-panel flex h-[560px] flex-col overflow-hidden">
+          <div className="flex-1 space-y-4 overflow-y-auto p-6">
+            {session.events.map((message, index) => {
+              const isUser = message.role === "user";
+              return (
+                <div
+                  key={`${message.role}-${index}-${message.createdAt}`}
+                  className={`flex items-end gap-3 ${isUser ? "justify-end" : "justify-start"}`}
+                >
+                  {!isUser && (
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-accent/10">
+                      <Bot className="h-4 w-4 text-accent" />
+                    </div>
+                  )}
+                  <div
+                    className={`max-w-[75%] rounded-2xl px-4 py-3 text-sm leading-relaxed shadow-lg ${
+                      isUser ? "bg-accent text-slate-950" : "bg-white/5 text-slate-100 backdrop-blur"
+                    }`}
+                  >
+                    <p>{message.content}</p>
+                    <span className="mt-1 block text-[10px] uppercase tracking-[0.25em] text-slate-500">
+                      {formatTimestamp(message)}
+                    </span>
+                  </div>
+                  {isUser && (
+                    <div className="flex h-8 w-8 items-center justify-center rounded-full bg-white/10">
+                      <User className="h-4 w-4 text-white" />
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+            {isPending && (
+              <div className="flex items-center gap-2 text-xs uppercase tracking-[0.3em] text-slate-500">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Génération en cours…
+              </div>
+            )}
+          </div>
+          <form
+            className="border-t border-white/5 bg-black/40 p-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              handleSubmit(input);
+            }}
+          >
+            <div className="flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-2">
+              <Mic className="h-4 w-4 text-slate-400" />
+              <input
+                value={input}
+                onChange={(event) => setInput(event.target.value)}
+                placeholder="Demandez une analyse MQ/GP/GF ou une action MCP..."
+                className="flex-1 bg-transparent text-sm text-slate-100 outline-none"
+              />
+              <Paperclip className="h-4 w-4 text-slate-500" />
+              <button type="submit" className="rounded-full bg-accent/90 p-2 hover:bg-accent">
+                <Send className="h-4 w-4 text-slate-950" />
+              </button>
+            </div>
+            {error && <p className="mt-2 text-xs text-red-400">{error}</p>}
+          </form>
+        </div>
+
+        <aside className="glass-panel space-y-4 p-6">
+          <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-400">
+            Suggestions rapides
+          </h3>
+          <div className="space-y-2">
+            {suggestions.length === 0 ? (
+              <p className="rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-slate-400">
+                Aucune suggestion enregistrée pour ce workspace. Interrogez le Copilot ou enregistrez des insights pour
+                alimenter cette liste.
+              </p>
+            ) : (
+              suggestions.map((prompt) => (
+                <button
+                  key={prompt}
+                  type="button"
+                  onClick={() => handleSubmit(prompt)}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-left text-sm text-slate-200 transition hover:border-accent-subtle"
+                >
+                  {prompt}
+                </button>
+              ))
+            )}
+          </div>
+          <p className="text-xs text-slate-500">
+            L’agent est connecté aux serveurs MCP Google/Meta/LinkedIn/TikTok/Amazon et au semantic layer OrionPulse.
+          </p>
+          <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+            <p className="text-[10px] uppercase tracking-[0.3em] text-slate-500">Payload agent</p>
+            <pre className="mt-2 max-h-32 overflow-y-auto text-[11px] leading-relaxed text-slate-400">
+              {JSON.stringify(agentPreview, null, 2)}
+            </pre>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/components/integrations/status-pill.tsx
+++ b/components/integrations/status-pill.tsx
@@ -1,0 +1,6 @@
+import { integrationStatusTone, type McpIntegration } from "@/lib/data/integrations";
+import { Pill } from "@/components/ui/pill";
+
+export function StatusPill({ status }: { status: McpIntegration["status"] }) {
+  return <Pill className={integrationStatusTone[status]}>{status}</Pill>;
+}

--- a/components/navigation/sidebar-client.tsx
+++ b/components/navigation/sidebar-client.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { type McpIntegration, integrationStatusTone } from "@/lib/data/integrations";
+import { navItems } from "@/data/navigation";
+import { cn } from "@/lib/utils";
+
+export function SidebarClient({ integrations }: { integrations: McpIntegration[] }) {
+  const pathname = usePathname();
+
+  return (
+    <aside className="w-72 border-r border-white/5 bg-black/30 backdrop-blur-xl p-8 flex flex-col gap-8">
+      <div className="flex items-center gap-3">
+        <div className="h-10 w-10 rounded-full bg-accent/20 grid place-items-center">
+          <span className="text-accent font-semibold">OP</span>
+        </div>
+        <div>
+          <p className="font-semibold">OrionPulse</p>
+          <p className="text-xs text-slate-400">Copilot marketing MQ · GP · GF</p>
+        </div>
+      </div>
+
+      <nav className="flex-1 space-y-2">
+        {navItems.map((item) => {
+          const active = pathname?.startsWith(item.href);
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={cn(
+                "flex items-start gap-3 rounded-xl border border-transparent px-4 py-3 transition-colors",
+                active ? "bg-accent/10 border-accent/40 text-accent-subtle" : "hover:bg-white/5 text-slate-300"
+              )}
+            >
+              <item.icon className="mt-0.5 h-5 w-5" />
+              <span>
+                <p className="font-medium">{item.title}</p>
+                <p className="text-xs text-slate-400">{item.description}</p>
+              </span>
+            </Link>
+          );
+        })}
+      </nav>
+
+      <div className="space-y-4">
+        <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+          <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Connecteurs MCP</p>
+          <ul className="mt-3 space-y-2">
+            {integrations.slice(0, 3).map((integration) => (
+              <li
+                key={integration.id}
+                className="flex items-center justify-between text-xs text-slate-300"
+              >
+                <span className="truncate pr-2">{integration.platform}</span>
+                <span
+                  className={cn(
+                    "rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                    integrationStatusTone[integration.status]
+                  )}
+                >
+                  {integration.status}
+                </span>
+              </li>
+            ))}
+            {integrations.length === 0 && (
+              <li className="text-xs text-slate-500">Aucun connecteur configuré.</li>
+            )}
+          </ul>
+          <p className="mt-3 text-[11px] text-slate-500">Etat complet dans Admin → Integrations.</p>
+        </div>
+
+        <div className="text-xs text-slate-500 space-y-1">
+          <p>Dernière synchro MCP · automatique</p>
+          <p>Quota appels restants : 82%</p>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/components/navigation/sidebar.tsx
+++ b/components/navigation/sidebar.tsx
@@ -1,0 +1,17 @@
+import { headers } from "next/headers";
+
+import { SidebarClient } from "@/components/navigation/sidebar-client";
+import { fetchMcpIntegrations } from "@/lib/data/integrations";
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+
+async function loadWorkspaceId() {
+  const supabase = createServiceRoleClient();
+  return resolveWorkspaceId(headers(), supabase);
+}
+
+export async function Sidebar() {
+  const workspaceId = await loadWorkspaceId();
+  const integrations = await fetchMcpIntegrations(workspaceId);
+  return <SidebarClient integrations={integrations} />;
+}

--- a/components/navigation/topbar.tsx
+++ b/components/navigation/topbar.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { CalendarDays, ChevronDown, Cloud, Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const territories = [
+  { code: "MQ", label: "Martinique" },
+  { code: "GP", label: "Guadeloupe" },
+  { code: "GF", label: "Guyane" }
+];
+
+const ranges = [
+  { id: "7d", label: "7 derniers jours" },
+  { id: "14d", label: "14 derniers jours" },
+  { id: "30d", label: "30 derniers jours" },
+  { id: "custom", label: "Personnalisé" }
+];
+
+export function Topbar() {
+  const [territory, setTerritory] = useState("MQ");
+  const [range, setRange] = useState("7d");
+
+  return (
+    <header className="sticky top-0 z-40 flex flex-wrap items-center gap-4 border-b border-white/5 bg-black/60 px-10 py-6 backdrop-blur-xl">
+      <button className="group flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm transition hover:border-accent hover:text-accent" onClick={() => setTerritory(nextTerritory(territory))}>
+        <Cloud className="h-4 w-4 text-accent" />
+        {territories.find((t) => t.code === territory)?.label ?? "MQ"}
+        <ChevronDown className="h-4 w-4 opacity-60" />
+      </button>
+
+      <div className="flex items-center gap-2 rounded-full border border-white/10 px-4 py-2 text-sm text-slate-300">
+        <CalendarDays className="h-4 w-4 text-accent" />
+        <div className="flex gap-2">
+          {ranges.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => setRange(item.id)}
+              className={cn(
+                "rounded-full px-3 py-1 text-xs transition",
+                range === item.id ? "bg-accent/20 text-accent" : "hover:bg-white/10"
+              )}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <label className="relative ml-auto flex h-10 flex-1 min-w-[240px] items-center overflow-hidden rounded-full border border-white/10 bg-white/5 px-4 text-sm text-slate-300">
+        <Search className="mr-3 h-4 w-4 text-accent" />
+        <input
+          type="search"
+          placeholder="Rechercher ou taper / pour le copilot"
+          className="h-full flex-1 bg-transparent outline-none placeholder:text-slate-500"
+        />
+      </label>
+    </header>
+  );
+}
+
+function nextTerritory(code: string) {
+  const index = territories.findIndex((t) => t.code === code);
+  if (index === -1) return territories[0]?.code ?? "MQ";
+  return territories[(index + 1) % territories.length]!.code;
+}

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+
+export type Column<T> = {
+  header: string;
+  accessor: (row: T) => ReactNode;
+};
+
+export function DataTable<T>({ data, columns }: { data: T[]; columns: Column<T>[] }) {
+  return (
+    <div className="overflow-hidden rounded-2xl border border-white/5">
+      <table className="min-w-full divide-y divide-white/10 bg-surface/40">
+        <thead className="bg-white/5 text-left text-xs uppercase tracking-[0.3em] text-slate-400">
+          <tr>
+            {columns.map((column) => (
+              <th key={column.header} className="px-4 py-3">
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-white/5">
+          {data.map((row, index) => (
+            <tr key={index} className="text-sm text-slate-200">
+              {columns.map((column) => (
+                <td key={column.header} className="px-4 py-3">
+                  {column.accessor(row)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/ui/pill.tsx
+++ b/components/ui/pill.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export function Pill({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-slate-300",
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/components/ui/resource-link.tsx
+++ b/components/ui/resource-link.tsx
@@ -1,0 +1,25 @@
+import { ArrowUpRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type ResourceLinkProps = {
+  href: string;
+  label: string;
+  className?: string;
+};
+
+export function ResourceLink({ href, label, className }: ResourceLinkProps) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        "group inline-flex items-center gap-1 text-xs font-medium text-accent hover:text-accent-muted",
+        className
+      )}
+    >
+      <span>{label}</span>
+      <ArrowUpRight className="h-3.5 w-3.5 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+    </a>
+  );
+}

--- a/components/ui/section-header.tsx
+++ b/components/ui/section-header.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+export function SectionHeader({ title, description, action }: { title: string; description?: string; action?: ReactNode }) {
+  return (
+    <div className="flex flex-wrap items-end justify-between gap-4">
+      <div>
+        <h2 className="text-2xl font-semibold text-slate-100">{title}</h2>
+        {description ? <p className="text-sm text-slate-400">{description}</p> : null}
+      </div>
+      {action}
+    </div>
+  );
+}

--- a/data/mcp-registry.json
+++ b/data/mcp-registry.json
@@ -1,0 +1,244 @@
+[
+  {
+    "slug": "google_ads",
+    "label": "Google Ads",
+    "docs": "https://github.com/google-marketing-solutions/google-ads-mcp-server",
+    "transports": ["STDIO", "HTTP SSE"],
+    "defaultServerUrl": "stdio:npx google-ads-mcp",
+    "defaultStatus": "unknown",
+    "env": {
+      "serverUrl": "MCP_GOOGLE_ADS_URL",
+      "status": "MCP_GOOGLE_ADS_STATUS"
+    },
+    "authVariables": [
+      { "name": "GOOGLE_ADS_DEVELOPER_TOKEN", "description": "Developer token issued from the Google Ads UI", "required": true },
+      { "name": "GOOGLE_ADS_CLIENT_ID", "description": "OAuth client id from Google Cloud Console", "required": true },
+      { "name": "GOOGLE_ADS_CLIENT_SECRET", "description": "OAuth client secret from Google Cloud Console", "required": true },
+      { "name": "GOOGLE_ADS_REFRESH_TOKEN", "description": "Refresh token created through the OAuth consent flow", "required": true },
+      { "name": "GOOGLE_ADS_LOGIN_CUSTOMER_ID", "description": "(Optionnel) ID manager pour accéder aux comptes enfants", "required": false },
+      { "name": "GOOGLE_ADS_YAML", "description": "Chemin vers google-ads.yaml si vous utilisez le transport STDIO", "required": false }
+    ],
+    "notes": [
+      "Activer l'API Google Ads sur le projet GCP et approuver le developer token.",
+      "Le serveur MCP expose GAQL via l'outil search_stream."
+    ]
+  },
+  {
+    "slug": "meta_ads",
+    "label": "Meta Ads",
+    "docs": "https://github.com/wiiip/meta-mcp",
+    "transports": ["STDIO", "HTTP SSE"],
+    "defaultServerUrl": "stdio:npx meta-mcp",
+    "defaultStatus": "unknown",
+    "env": {
+      "serverUrl": "MCP_META_ADS_URL",
+      "status": "MCP_META_ADS_STATUS"
+    },
+    "authVariables": [
+      { "name": "META_ACCESS_TOKEN", "description": "User ou system access token avec ads_read / ads_management", "required": true },
+      { "name": "META_APP_ID", "description": "App id si vous orchestrez le flow OAuth", "required": false },
+      { "name": "META_APP_SECRET", "description": "App secret pour rafraîchir le token", "required": false }
+    ],
+    "notes": [
+      "Vérifier l'accès avancé (Advanced Access) pour ads_management.",
+      "Suivre le scoring rate-limit fourni par l'API Marketing."
+    ]
+  },
+  {
+    "slug": "linkedin_ads",
+    "label": "LinkedIn Ads",
+    "docs": "https://github.com/radiateb2b/mcp-linkedinads",
+    "transports": ["HTTP SSE"],
+    "defaultServerUrl": "https://linkedinads.radiateb2b.com/sse",
+    "defaultStatus": "online",
+    "env": {
+      "serverUrl": "MCP_LINKEDIN_ADS_URL",
+      "status": "MCP_LINKEDIN_ADS_STATUS",
+      "authHeader": "MCP_LINKEDIN_ADS_TOKEN"
+    },
+    "authVariables": [
+      { "name": "MCP_LINKEDIN_ADS_TOKEN", "description": "Private access token fourni par RadiateB2B", "required": true }
+    ],
+    "notes": [
+      "Solution managée lecture seule, idéal pour démarrer sans self-host.",
+      "Déclarer le header Authorization: Bearer <token> dans la config agent."
+    ]
+  },
+  {
+    "slug": "tiktok_ads",
+    "label": "TikTok Ads",
+    "docs": "https://github.com/ysntony/tiktok-ads-mcp",
+    "transports": ["STDIO"],
+    "defaultServerUrl": "stdio:npx tiktok-ads-mcp",
+    "defaultStatus": "unknown",
+    "env": {
+      "serverUrl": "MCP_TIKTOK_ADS_URL",
+      "status": "MCP_TIKTOK_ADS_STATUS"
+    },
+    "authVariables": [
+      { "name": "TIKTOK_APP_ID", "description": "Identifiant d'app TikTok for Business", "required": true },
+      { "name": "TIKTOK_APP_SECRET", "description": "Secret d'app TikTok for Business", "required": true },
+      { "name": "TIKTOK_ACCESS_TOKEN", "description": "Access token annonceur obtenu via OAuth v2", "required": true }
+    ],
+    "notes": [
+      "Respecter les scopes requis par TikTok Business API.",
+      "Configurer les fenêtres de gel pour éviter les appels nocturnes."
+    ]
+  },
+  {
+    "slug": "amazon_ads",
+    "label": "Amazon Ads",
+    "docs": "https://github.com/MarketplaceAdPros/amazon-ads-mcp-server",
+    "transports": ["STDIO", "HTTP SSE"],
+    "defaultServerUrl": "https://app.marketplaceadpros.com/mcp",
+    "defaultStatus": "unknown",
+    "env": {
+      "serverUrl": "MCP_AMAZON_ADS_URL",
+      "status": "MCP_AMAZON_ADS_STATUS",
+      "authHeader": "MCP_AMAZON_ADS_TOKEN"
+    },
+    "authVariables": [
+      { "name": "MCP_AMAZON_ADS_TOKEN", "description": "Bearer token fourni par MarketplaceAdPros ou vos propres identifiants Advertising", "required": true }
+    ],
+    "notes": [
+      "Supporte STDIO self-host et instance managée HTTP SSE.",
+      "Prévoir la rotation du token toutes les 12 heures."
+    ]
+  },
+  {
+    "slug": "google_analytics",
+    "label": "Google Analytics 4",
+    "docs": "https://github.com/googleanalytics/google-analytics-mcp",
+    "transports": ["STDIO"],
+    "defaultServerUrl": "stdio:npx google-analytics-mcp",
+    "defaultStatus": "unknown",
+    "env": {
+      "serverUrl": "MCP_GOOGLE_ANALYTICS_URL",
+      "status": "MCP_GOOGLE_ANALYTICS_STATUS"
+    },
+    "authVariables": [
+      { "name": "GOOGLE_APPLICATION_CREDENTIALS", "description": "Chemin vers la clé JSON ADC avec scope analytics.readonly", "required": true },
+      { "name": "GOOGLE_PROJECT_ID", "description": "Projet GCP associé aux credentials", "required": true }
+    ],
+    "notes": [
+      "Activer Analytics Admin API et Data API avant utilisation.",
+      "Compatible avec impersonation de compte de service."
+    ]
+  },
+  {
+    "slug": "data_commons",
+    "label": "Data Commons",
+    "docs": "https://docs.datacommons.org/tools/mcp.html",
+    "transports": ["HTTP SSE"],
+    "defaultServerUrl": "https://mcp.datacommons.org/sse",
+    "defaultStatus": "online",
+    "env": {
+      "serverUrl": "MCP_DATA_COMMONS_URL",
+      "status": "MCP_DATA_COMMONS_STATUS"
+    },
+    "authVariables": [],
+    "notes": [
+      "Lecture publique (pas d'auth).",
+      "Idéal pour contextualiser les analyses MQ/GP/GF avec données socio-éco."
+    ]
+  },
+  {
+    "slug": "slack",
+    "label": "Slack",
+    "docs": "https://github.com/korotovsky/slack-mcp-server",
+    "transports": ["STDIO", "HTTP SSE"],
+    "defaultServerUrl": "stdio:npx slack-mcp-server",
+    "defaultStatus": "unknown",
+    "env": {
+      "serverUrl": "MCP_SLACK_URL",
+      "status": "MCP_SLACK_STATUS"
+    },
+    "authVariables": [
+      { "name": "SLACK_MCP_XOXP_TOKEN", "description": "Token utilisateur OAuth si mode stealth", "required": false },
+      { "name": "SLACK_MCP_XOXC_TOKEN", "description": "Token cookie xoxc pour mode navigateur (dev uniquement)", "required": false },
+      { "name": "SLACK_MCP_API_KEY", "description": "Clé API optionnelle pour sécuriser l'accès HTTP/SSE", "required": false }
+    ],
+    "notes": [
+      "Préférer un bot OAuth dédié en production.",
+      "Limiter les scopes (chat:write, channels:read) au strict nécessaire."
+    ]
+  },
+  {
+    "slug": "notion",
+    "label": "Notion",
+    "docs": "https://www.notion.so/product/notion-ai",
+    "transports": ["HTTP", "HTTP SSE"],
+    "defaultServerUrl": "https://mcp.notion.com/mcp",
+    "defaultStatus": "online",
+    "env": {
+      "serverUrl": "MCP_NOTION_URL",
+      "status": "MCP_NOTION_STATUS"
+    },
+    "authVariables": [],
+    "notes": [
+      "OAuth côté Notion (pas de secret stocké).",
+      "Limiter l'accès aux espaces clients pertinents."
+    ]
+  },
+  {
+    "slug": "atlassian",
+    "label": "Atlassian (Confluence/Jira)",
+    "docs": "https://community.atlassian.com/t5/Automation-discussions/Introducing-the-Atlassian-MCP/td-p/2672841",
+    "transports": ["HTTP SSE"],
+    "defaultServerUrl": "https://mcp.atlassian.com/sse",
+    "defaultStatus": "unknown",
+    "env": {
+      "serverUrl": "MCP_ATLASSIAN_URL",
+      "status": "MCP_ATLASSIAN_STATUS",
+      "authHeader": "MCP_ATLASSIAN_TOKEN"
+    },
+    "authVariables": [
+      { "name": "MCP_ATLASSIAN_TOKEN", "description": "Token OAuth 2.1 Atlassian Cloud ou API token self-host", "required": true }
+    ],
+    "notes": [
+      "Disponible en BETA officielle côté Atlassian.",
+      "Permet de créer issues, pages et commentaires via runbooks."
+    ]
+  },
+  {
+    "slug": "google_drive",
+    "label": "Google Drive / Sheets",
+    "docs": "https://github.com/googleworkspace/google-drive-mcp",
+    "transports": ["STDIO", "HTTP"],
+    "defaultServerUrl": "stdio:npx google-drive-mcp",
+    "defaultStatus": "unknown",
+    "env": {
+      "serverUrl": "MCP_GOOGLE_DRIVE_URL",
+      "status": "MCP_GOOGLE_DRIVE_STATUS"
+    },
+    "authVariables": [
+      { "name": "GOOGLE_DRIVE_CLIENT_ID", "description": "Client id OAuth", "required": true },
+      { "name": "GOOGLE_DRIVE_CLIENT_SECRET", "description": "Client secret OAuth", "required": true },
+      { "name": "GOOGLE_DRIVE_REFRESH_TOKEN", "description": "Refresh token utilisateur/service", "required": true }
+    ],
+    "notes": [
+      "Activer Google Drive API et Sheets API si nécessaire.",
+      "Utile pour partager exports et briefs créatifs."
+    ]
+  },
+  {
+    "slug": "dagster",
+    "label": "Dagster",
+    "docs": "https://github.com/kyryl-opens-ml/mcp-server-dagster",
+    "transports": ["STDIO", "HTTP"],
+    "defaultServerUrl": "stdio:npx mcp-server-dagster",
+    "defaultStatus": "unknown",
+    "env": {
+      "serverUrl": "MCP_DAGSTER_URL",
+      "status": "MCP_DAGSTER_STATUS"
+    },
+    "authVariables": [
+      { "name": "DAGSTER_GRAPHQL_URL", "description": "Endpoint GraphQL de votre instance Dagster", "required": true },
+      { "name": "DAGSTER_API_TOKEN", "description": "Token/API key pour Dagster Cloud ou instance self-host", "required": true }
+    ],
+    "notes": [
+      "Expose les jobs d'orchestration (sync, runbooks).",
+      "Permet aux agents GPT-5 de lancer des assets avec garde-fous."
+    ]
+  }
+]

--- a/data/navigation.ts
+++ b/data/navigation.ts
@@ -1,0 +1,104 @@
+import type { ComponentType } from "react";
+import {
+  BarChart4,
+  BellRing,
+  Bot,
+  Compass,
+  FileBarChart,
+  Gauge,
+  Map,
+  Palette,
+  Share2,
+  ShieldCheck,
+  Sparkles,
+  UserCog,
+  UserRound
+} from "lucide-react";
+
+export type NavItem = {
+  title: string;
+  description: string;
+  href: string;
+  icon: ComponentType<{ className?: string }>;
+};
+
+export const navItems: NavItem[] = [
+  {
+    title: "Overview",
+    description: "Vue globale MQ/GP/GF & santé des flux",
+    href: "/overview",
+    icon: Gauge
+  },
+  {
+    title: "Performance",
+    description: "Pivot campagnes/adsets/ads & KPIs",
+    href: "/performance",
+    icon: BarChart4
+  },
+  {
+    title: "Territories",
+    description: "Command center MQ · GP · GF",
+    href: "/territories",
+    icon: Map
+  },
+  {
+    title: "Opportunities",
+    description: "Anomalies & runbooks priorisés",
+    href: "/opportunities",
+    icon: Compass
+  },
+  {
+    title: "Planner",
+    description: "Simulations MMM & what-if",
+    href: "/planner",
+    icon: Sparkles
+  },
+  {
+    title: "Creatives",
+    description: "Fatigue & intelligence créative",
+    href: "/creatives",
+    icon: Palette
+  },
+  {
+    title: "Attribution",
+    description: "Lift tests, clean rooms, CAPI",
+    href: "/attribution",
+    icon: Share2
+  },
+  {
+    title: "Governance",
+    description: "Data contracts & policies",
+    href: "/governance",
+    icon: ShieldCheck
+  },
+  {
+    title: "Alerts",
+    description: "Garde-fous & notifications",
+    href: "/alerts",
+    icon: BellRing
+  },
+  {
+    title: "Reports",
+    description: "Templates & exports white-label",
+    href: "/reports",
+    icon: FileBarChart
+  },
+  {
+    title: "Copilot",
+    description: "GPT-5 multimodal in-app",
+    href: "/copilot",
+    icon: Bot
+  },
+  {
+    title: "Admin",
+    description: "Paramétrage, quotas, observabilité",
+    href: "/admin",
+    icon: UserCog
+  },
+  {
+    title: "Profile",
+    description: "Préférences & clés API",
+    href: "/profile",
+    icon: UserRound
+  }
+];

--- a/lib/ai/copilot.ts
+++ b/lib/ai/copilot.ts
@@ -1,0 +1,85 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { z } from "zod";
+
+const eventSchema = z.object({
+  role: z.enum(["user", "assistant", "system", "tool"]),
+  content: z.string(),
+  createdAt: z.date().optional()
+});
+
+type CopilotEvent = z.infer<typeof eventSchema>;
+
+export type CopilotSession = {
+  id: string;
+  workspaceId?: string;
+  territory?: string;
+  events: CopilotEvent[];
+};
+
+/**
+ * Prépare le client Supabase service-role pour enregistrer les conversations Copilot.
+ * En production l'URL et la clé seront injectées via environnement sécurisé (Edge Config / Vault).
+ */
+export function createCopilotStore(): SupabaseClient | null {
+  const url =
+    process.env.SUPABASE_URL ??
+    process.env.NEXT_PUBLIC_SUPABASE_URL ??
+    (process.env.SUPABASE_PROJECT_ID ? `https://${process.env.SUPABASE_PROJECT_ID}.supabase.co` : undefined);
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) {
+    return null;
+  }
+  return createClient(url, serviceKey, {
+    auth: {
+      persistSession: false
+    }
+  });
+}
+
+export function appendEvent(session: CopilotSession, event: CopilotEvent): CopilotSession {
+  const parsed = eventSchema.parse(event);
+  return {
+    ...session,
+    events: [...session.events, { ...parsed, createdAt: parsed.createdAt ?? new Date() }]
+  };
+}
+
+export function serializeForAgent(session: CopilotSession) {
+  return session.events.map(({ role, content }) => ({ role, content }));
+}
+
+export async function persistCopilotEvent(
+  session: CopilotSession,
+  event: CopilotEvent
+) {
+  const store = createCopilotStore();
+  if (!store) {
+    return;
+  }
+
+  try {
+    const sessionId = session.id;
+    const { data: existing } = await store
+      .from("copilot_sessions")
+      .select("id")
+      .eq("id", sessionId)
+      .maybeSingle();
+
+    if (!existing) {
+      await store.from("copilot_sessions").insert({
+        id: sessionId,
+        workspace_id: session.workspaceId ?? null,
+        territory: session.territory ?? null
+      });
+    }
+
+    await store.from("copilot_messages").insert({
+      session_id: sessionId,
+      role: event.role,
+      content: event.content,
+      created_at: event.createdAt?.toISOString() ?? new Date().toISOString()
+    });
+  } catch (error) {
+    console.warn("Impossible d'enregistrer la session Copilot", error);
+  }
+}

--- a/lib/ai/openai-agent.ts
+++ b/lib/ai/openai-agent.ts
@@ -1,0 +1,94 @@
+const OPENAI_BASE_URL = process.env.OPENAI_API_BASE ?? "https://api.openai.com/v1";
+const OPENAI_AGENT_ID = process.env.OPENAI_AGENT_ID;
+
+export type AgentMessage = {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+};
+
+type AgentRunResponse = {
+  output?: { type: string; content: { type: string; text?: string }[] }[];
+  result?: { type: string; content: { type: string; text?: string }[] }[];
+  status?: string;
+};
+
+async function fetchMcpToolResources(workspaceId?: string) {
+  if (!workspaceId) {
+    return [] as { type: string; server_url: string; name: string }[];
+  }
+  try {
+    const { createServiceRoleClient } = await import("@/lib/supabase/server");
+    const client = createServiceRoleClient();
+    const { data } = await client
+      .from("mcp_connections")
+      .select("provider,server_url,status")
+      .eq("workspace_id", workspaceId)
+      .in("status", ["online", "degraded"]);
+    return (
+      data ?? []
+    ).map((row) => ({
+      type: "mcp_server",
+      server_url: row.server_url,
+      name: row.provider
+    }));
+  } catch (error) {
+    console.warn("Impossible de charger les connecteurs MCP", error);
+    return [];
+  }
+}
+
+export async function invokeCopilotAgent(messages: AgentMessage[], workspaceId?: string): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey || !OPENAI_AGENT_ID) {
+    return "⚠️ L'agent OpenAI n'est pas configuré. Ajoutez OPENAI_API_KEY et OPENAI_AGENT_ID.";
+  }
+
+  const mcpTools = await fetchMcpToolResources(workspaceId);
+
+  const payload = {
+    agent_id: OPENAI_AGENT_ID,
+    input: messages.map((message) => ({ role: message.role, content: message.content })),
+    tool_resources: {
+      mcp_servers: mcpTools,
+      sql_datastores: [
+        {
+          type: "dbt_semantic_layer",
+          name: "orionpulse_semantic",
+          connection: process.env.DBT_SEMANTIC_CONNECTION ?? "semantic-layer"
+        }
+      ]
+    },
+    metadata: {
+      workspaceId
+    }
+  };
+
+  const response = await fetch(`${OPENAI_BASE_URL}/agents/runs`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+      "OpenAI-Beta": "agents=v1"
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    console.error("Erreur OpenAI", await response.text());
+    return "❌ Impossible de contacter OpenAI pour le moment. Réessayez plus tard.";
+  }
+
+  const data = (await response.json()) as AgentRunResponse;
+  const blocks = data.output ?? data.result ?? [];
+  for (const block of blocks) {
+    for (const fragment of block.content) {
+      if (fragment.type === "output_text" && fragment.text) {
+        return fragment.text.trim();
+      }
+      if (fragment.type === "text" && fragment.text) {
+        return fragment.text.trim();
+      }
+    }
+  }
+  return "Je n'ai pas pu générer de réponse, pouvez-vous reformuler votre demande ?";
+}

--- a/lib/data/alerts.ts
+++ b/lib/data/alerts.ts
@@ -1,0 +1,59 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+
+export type AlertRule = {
+  id: string;
+  name: string;
+  channel: string;
+  threshold: Record<string, unknown>;
+};
+
+export type AlertEvent = {
+  id: string;
+  ruleId: string;
+  status: string;
+  triggeredAt: string;
+  payload: Record<string, unknown>;
+};
+
+export async function fetchAlertRules(workspaceId: string): Promise<AlertRule[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("alert_rules")
+    .select("id,name,channel,threshold")
+    .eq("workspace_id", workspaceId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    name: row.name,
+    channel: row.channel,
+    threshold: row.threshold ?? {}
+  }));
+}
+
+export async function fetchAlertEvents(workspaceId: string): Promise<AlertEvent[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("alert_events")
+    .select("id,rule_id,status,payload,triggered_at,alert_rules(workspace_id)")
+    .order("triggered_at", { ascending: false })
+    .limit(50);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? [])
+    .filter((row) => row.alert_rules?.workspace_id === workspaceId)
+    .map((row) => ({
+      id: row.id,
+      ruleId: row.rule_id,
+      status: row.status,
+      triggeredAt: row.triggered_at,
+      payload: row.payload ?? {}
+    }));
+}

--- a/lib/data/anomalies.ts
+++ b/lib/data/anomalies.ts
@@ -1,0 +1,35 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+
+export type Anomaly = {
+  id: string;
+  detectedAt: string;
+  severity: string;
+  status: string;
+  dimension: Record<string, unknown>;
+  runbookId?: string | null;
+  description?: string | null;
+};
+
+export async function fetchAnomalies(workspaceId: string): Promise<Anomaly[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("anomaly_events")
+    .select("id,detected_at,severity,status,dimension,runbook_id,description")
+    .eq("workspace_id", workspaceId)
+    .order("detected_at", { ascending: false })
+    .limit(50);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    detectedAt: row.detected_at,
+    severity: row.severity,
+    status: row.status,
+    dimension: row.dimension ?? {},
+    runbookId: row.runbook_id,
+    description: row.description
+  }));
+}

--- a/lib/data/attribution.ts
+++ b/lib/data/attribution.ts
@@ -1,0 +1,34 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+
+export type LiftTest = {
+  id: string;
+  name: string;
+  status: string;
+  platform?: string | null;
+  territory?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+};
+
+export async function fetchLiftTests(workspaceId: string): Promise<LiftTest[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("lift_tests")
+    .select("id,name,status,platform,territory,start_date,end_date")
+    .eq("workspace_id", workspaceId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    name: row.name,
+    status: row.status,
+    platform: row.platform,
+    territory: row.territory,
+    startDate: row.start_date,
+    endDate: row.end_date
+  }));
+}

--- a/lib/data/copilot.ts
+++ b/lib/data/copilot.ts
@@ -1,0 +1,21 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+
+export async function fetchCopilotSuggestions(workspaceId: string): Promise<string[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("insights")
+    .select("title")
+    .eq("workspace_id", workspaceId)
+    .order("created_at", { ascending: false })
+    .limit(5);
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data?.length) {
+    return [];
+  }
+
+  return data.map((row) => `Explique ${row.title}`);
+}

--- a/lib/data/creatives.ts
+++ b/lib/data/creatives.ts
@@ -1,0 +1,37 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+
+export type CreativeAsset = {
+  id: string;
+  name: string;
+  platform: string;
+  status: string;
+  thumbnailUrl?: string | null;
+  fatigueScore?: number | null;
+  tags: string[];
+  lastSeenAt?: string | null;
+};
+
+export async function fetchCreativeAssets(workspaceId: string): Promise<CreativeAsset[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("creative_assets")
+    .select("id,name,platform,status,thumbnail_url,last_seen_at,metrics,creative_analysis(fatigue_score,tags)")
+    .eq("workspace_id", workspaceId)
+    .order("last_seen_at", { ascending: false })
+    .limit(60);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    name: row.name,
+    platform: row.platform,
+    status: row.status,
+    thumbnailUrl: row.thumbnail_url,
+    fatigueScore: row.creative_analysis?.fatigue_score ?? null,
+    tags: row.creative_analysis?.tags ?? [],
+    lastSeenAt: row.last_seen_at
+  }));
+}

--- a/lib/data/credentials.ts
+++ b/lib/data/credentials.ts
@@ -1,0 +1,108 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import {
+  mcpRegistry,
+  resolveMcpEntry,
+  type McpAuthVariable
+} from "@/lib/mcp/registry";
+
+export type CredentialStatus = "missing" | "active" | "expiring" | "expired";
+
+export type CredentialSummary = {
+  id?: string;
+  provider: string;
+  label: string;
+  status: CredentialStatus;
+  expiresAt: string | null;
+  lastRotatedAt: string | null;
+  requiredSecrets: McpAuthVariable[];
+  docsUrl?: string | null;
+};
+
+function computeStatus(expiresAt: string | null): CredentialStatus {
+  if (!expiresAt) {
+    return "active";
+  }
+
+  const now = Date.now();
+  const expiry = Date.parse(expiresAt);
+  if (Number.isNaN(expiry)) {
+    return "active";
+  }
+
+  if (expiry <= now) {
+    return "expired";
+  }
+
+  const sevenDays = 7 * 24 * 60 * 60 * 1000;
+  if (expiry - now <= sevenDays) {
+    return "expiring";
+  }
+
+  return "active";
+}
+
+type CredentialRow = {
+  id: string;
+  provider: string;
+  expires_at: string | null;
+  created_at: string | null;
+};
+
+export async function fetchCredentialSummaries(
+  workspaceId: string
+): Promise<CredentialSummary[]> {
+  const client = createServiceRoleClient();
+
+  const { data, error } = await client
+    .from("credentials")
+    .select("id,provider,expires_at,created_at")
+    .eq("workspace_id", workspaceId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  const recordsByProvider = new Map<string, CredentialRow>();
+  for (const record of (data ?? []) as CredentialRow[]) {
+    recordsByProvider.set(record.provider.toLowerCase(), record);
+  }
+
+  const summaries: CredentialSummary[] = [];
+
+  for (const entry of mcpRegistry) {
+    const record = recordsByProvider.get(entry.slug.toLowerCase());
+    const expiresAt = record?.expires_at ?? null;
+    const summary: CredentialSummary = {
+      id: record?.id,
+      provider: entry.slug,
+      label: entry.label,
+      status: record ? computeStatus(expiresAt) : "missing",
+      expiresAt,
+      lastRotatedAt: record?.created_at ?? null,
+      requiredSecrets: entry.authVariables ?? [],
+      docsUrl: entry.docs ?? null
+    };
+    summaries.push(summary);
+    if (record) {
+      recordsByProvider.delete(entry.slug.toLowerCase());
+    }
+  }
+
+  for (const remaining of recordsByProvider.values()) {
+    const blueprint = resolveMcpEntry(remaining.provider);
+    const expiresAt = remaining.expires_at ?? null;
+    summaries.push({
+      id: remaining.id,
+      provider: remaining.provider,
+      label: blueprint?.label ?? remaining.provider,
+      status: computeStatus(expiresAt),
+      expiresAt,
+      lastRotatedAt: remaining.created_at ?? null,
+      requiredSecrets: blueprint?.authVariables ?? [],
+      docsUrl: blueprint?.docs ?? null
+    });
+  }
+
+  return summaries;
+}

--- a/lib/data/governance.ts
+++ b/lib/data/governance.ts
@@ -1,0 +1,46 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+
+export type GovernanceTask = {
+  id: string;
+  title: string;
+  owner: string;
+  due?: string | null;
+  status: string;
+};
+
+export async function fetchGovernanceTasks(workspaceId: string): Promise<GovernanceTask[]> {
+  const client = createServiceRoleClient();
+
+  const [{ data: approvals }, { data: jobs }] = await Promise.all([
+    client
+      .from("approvals")
+      .select("id,status,approved_at,approver,opportunity_id")
+      .eq("workspace_id", workspaceId)
+      .order("approved_at", { ascending: false })
+      .limit(10),
+    client
+      .from("sync_jobs")
+      .select("id,provider,status,scheduled_for")
+      .eq("workspace_id", workspaceId)
+      .order("scheduled_for", { ascending: true })
+      .limit(10)
+  ]);
+
+  const approvalTasks = (approvals ?? []).map((approval) => ({
+    id: approval.id,
+    title: `Approbation MCP · ${approval.opportunity_id ?? "opportunité"}`,
+    owner: approval.approver ?? "Non assigné",
+    due: approval.approved_at,
+    status: approval.status
+  }));
+
+  const jobTasks = (jobs ?? []).map((job) => ({
+    id: job.id,
+    title: `Sync ${job.provider}`,
+    owner: "Data Ops",
+    due: job.scheduled_for,
+    status: job.status
+  }));
+
+  return [...approvalTasks, ...jobTasks];
+}

--- a/lib/data/insights.ts
+++ b/lib/data/insights.ts
@@ -1,0 +1,33 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+
+export type Insight = {
+  id: string;
+  title: string;
+  body: string;
+  impact?: number | null;
+  territory?: string | null;
+  status: string;
+};
+
+export async function fetchInsights(workspaceId: string): Promise<Insight[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("insights")
+    .select("id,title,body,impact,territory,status")
+    .eq("workspace_id", workspaceId)
+    .order("created_at", { ascending: false })
+    .limit(20);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    title: row.title,
+    body: row.body,
+    impact: row.impact,
+    territory: row.territory,
+    status: row.status
+  }));
+}

--- a/lib/data/integrations.ts
+++ b/lib/data/integrations.ts
@@ -1,0 +1,58 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { computeTransportLabel, resolveMcpEntry } from "@/lib/mcp/registry";
+
+export type McpIntegrationStatus = "online" | "degraded" | "offline" | "unknown";
+
+export type McpIntegration = {
+  id: string;
+  provider: string;
+  platform: string;
+  status: McpIntegrationStatus;
+  transport: string;
+  serverUrl: string;
+  rateLimitNote?: string | null;
+  updatedAt?: string | null;
+  docsUrl?: string | null;
+  envVar?: string | null;
+};
+
+export const integrationStatusTone: Record<McpIntegrationStatus, string> = {
+  online: "border-emerald-400/40 bg-emerald-400/10 text-emerald-200",
+  degraded: "border-amber-300/40 bg-amber-300/10 text-amber-100",
+  offline: "border-rose-400/40 bg-rose-400/10 text-rose-200",
+  unknown: "border-slate-500/40 bg-slate-500/10 text-slate-200"
+};
+
+export async function fetchMcpIntegrations(workspaceId: string): Promise<McpIntegration[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("mcp_connections")
+    .select("id,provider,status,server_url,last_health_check")
+    .eq("workspace_id", workspaceId)
+    .order("provider", { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row) => {
+    const blueprint = resolveMcpEntry(row.provider);
+    const status = (row.status as McpIntegrationStatus) ?? "unknown";
+
+    return {
+      id: row.id,
+      provider: row.provider,
+      platform: blueprint?.label ?? row.provider,
+      status,
+      transport: computeTransportLabel(
+        blueprint,
+        row.server_url?.startsWith("http") ? "HTTP SSE" : "STDIO"
+      ),
+      serverUrl: row.server_url,
+      updatedAt: row.last_health_check,
+      rateLimitNote: null,
+      docsUrl: blueprint?.docs ?? null,
+      envVar: blueprint?.env?.serverUrl ?? null
+    } satisfies McpIntegration;
+  });
+}

--- a/lib/data/opportunities.ts
+++ b/lib/data/opportunities.ts
@@ -1,0 +1,48 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+
+export type Opportunity = {
+  id: string;
+  title: string;
+  summary?: string | null;
+  score: number | null;
+  status: string;
+  territory?: string | null;
+  eta?: string | null;
+  ownerId?: string | null;
+  ownerName?: string | null;
+};
+
+export async function fetchOpportunities(workspaceId: string): Promise<Opportunity[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("opportunities")
+    .select("id,title,summary,score,status,territory,eta,owner,users(full_name,email)")
+    .eq("workspace_id", workspaceId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row: {
+    id: string;
+    title?: string | null;
+    summary?: string | null;
+    score?: number | null;
+    status: string;
+    territory?: string | null;
+    eta?: string | null;
+    owner?: string | null;
+    users?: { full_name?: string | null; email?: string | null } | null;
+  }) => ({
+    id: row.id,
+    title: row.title ?? "Opportunity",
+    summary: row.summary ?? null,
+    score: row.score == null ? null : Number(row.score),
+    status: row.status,
+    territory: row.territory,
+    eta: row.eta,
+    ownerId: row.owner,
+    ownerName: row.users?.full_name ?? row.users?.email ?? null
+  }));
+}

--- a/lib/data/overview.ts
+++ b/lib/data/overview.ts
@@ -1,0 +1,148 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+
+export type KpiSummary = {
+  label: string;
+  value: number;
+  delta?: number | null;
+};
+
+export type TerritoryPerformance = {
+  territory: string;
+  spend: number;
+  roas: number | null;
+};
+
+export type SyncStatus = {
+  provider: string;
+  status: string;
+  lastRun: string | null;
+  nextRun: string | null;
+};
+
+export type ActiveAlert = {
+  id: string;
+  title: string;
+  runbook?: string | null;
+  status: string;
+  impact?: string | null;
+  triggeredAt: string;
+};
+
+export async function fetchKpiSummary(workspaceId: string): Promise<KpiSummary[]> {
+  const client = createServiceRoleClient();
+
+  const { data, error } = await client
+    .from("v_kpi_summary")
+    .select("observed_at,total_spend,total_conversions,total_revenue,avg_roas,avg_cpa")
+    .eq("workspace_id", workspaceId)
+    .order("observed_at", { ascending: false })
+    .limit(2);
+
+  if (error) {
+    throw error;
+  }
+
+  if (!data?.length) {
+    return [];
+  }
+
+  const latest = data[0];
+  const previous = data[1] ?? null;
+
+  const safeDelta = (current?: number | null, prev?: number | null) => {
+    if (current == null || prev == null) {
+      return null;
+    }
+    if (prev === 0) {
+      return null;
+    }
+    return ((current - prev) / prev) * 100;
+  };
+
+  return [
+    {
+      label: "Investissement",
+      value: Number(latest.total_spend ?? 0),
+      delta: safeDelta(Number(latest.total_spend ?? 0), Number(previous?.total_spend ?? 0))
+    },
+    {
+      label: "Conversions",
+      value: Number(latest.total_conversions ?? 0),
+      delta: safeDelta(Number(latest.total_conversions ?? 0), Number(previous?.total_conversions ?? 0))
+    },
+    {
+      label: "ROAS",
+      value: Number(latest.avg_roas ?? 0),
+      delta: safeDelta(Number(latest.avg_roas ?? 0), Number(previous?.avg_roas ?? 0))
+    },
+    {
+      label: "CPA",
+      value: Number(latest.avg_cpa ?? 0),
+      delta: safeDelta(Number(latest.avg_cpa ?? 0), Number(previous?.avg_cpa ?? 0))
+    }
+  ];
+}
+
+export async function fetchTerritoryPerformance(workspaceId: string): Promise<TerritoryPerformance[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("v_territory_performance")
+    .select("territory,spend,roas")
+    .eq("workspace_id", workspaceId)
+    .order("spend", { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? [])
+    .filter((row): row is typeof row & { territory: string } => Boolean(row.territory))
+    .map((row) => ({
+      territory: row.territory!,
+      spend: Number(row.spend ?? 0),
+      roas: row.roas == null ? null : Number(row.roas)
+    }));
+}
+
+export async function fetchSyncStatus(workspaceId: string): Promise<SyncStatus[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("v_sync_status")
+    .select("provider,status,last_finished,next_run")
+    .eq("workspace_id", workspaceId)
+    .order("provider", { ascending: true });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row) => ({
+    provider: row.provider,
+    status: row.status,
+    lastRun: row.last_finished ? new Date(row.last_finished).toLocaleString("fr-FR") : null,
+    nextRun: row.next_run ? new Date(row.next_run).toLocaleString("fr-FR") : null
+  }));
+}
+
+export async function fetchActiveAlerts(workspaceId: string): Promise<ActiveAlert[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("v_active_alerts")
+    .select("id,name,payload,status,triggered_at")
+    .eq("workspace_id", workspaceId)
+    .order("triggered_at", { ascending: false })
+    .limit(10);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    title: row.name,
+    runbook: row.payload?.runbook ?? null,
+    impact: row.payload?.impact ?? null,
+    status: row.status,
+    triggeredAt: row.triggered_at
+  }));
+}

--- a/lib/data/performance.ts
+++ b/lib/data/performance.ts
@@ -1,0 +1,60 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+
+export type PerformanceRow = {
+  observedAt: string;
+  platform: string;
+  campaign?: string | null;
+  territory?: string | null;
+  spend: number;
+  impressions: number;
+  clicks: number;
+  conversions: number;
+  revenue: number;
+  cpa: number | null;
+  roas: number | null;
+};
+
+export async function fetchPerformanceRows(
+  workspaceId: string,
+  params: { territory?: string; platform?: string; startDate?: string; endDate?: string }
+): Promise<PerformanceRow[]> {
+  const client = createServiceRoleClient();
+  let query = client
+    .from("v_kpi_daily")
+    .select("observed_at,platform,territory,spend,impressions,clicks,conversions,revenue,cpa,roas")
+    .eq("workspace_id", workspaceId)
+    .order("observed_at", { ascending: false })
+    .limit(180);
+
+  if (params.territory) {
+    query = query.eq("territory", params.territory);
+  }
+  if (params.platform) {
+    query = query.eq("platform", params.platform);
+  }
+  if (params.startDate) {
+    query = query.gte("observed_at", params.startDate);
+  }
+  if (params.endDate) {
+    query = query.lte("observed_at", params.endDate);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row) => ({
+    observedAt: row.observed_at,
+    platform: row.platform,
+    territory: row.territory,
+    spend: Number(row.spend ?? 0),
+    impressions: Number(row.impressions ?? 0),
+    clicks: Number(row.clicks ?? 0),
+    conversions: Number(row.conversions ?? 0),
+    revenue: Number(row.revenue ?? 0),
+    cpa: row.cpa == null ? null : Number(row.cpa),
+    roas: row.roas == null ? null : Number(row.roas)
+  }));
+}

--- a/lib/data/planner.ts
+++ b/lib/data/planner.ts
@@ -1,0 +1,32 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+
+export type PlannerScenario = {
+  id: string;
+  name: string;
+  status: string;
+  objective: Record<string, unknown>;
+  assumptions: Record<string, unknown>;
+  createdAt: string;
+};
+
+export async function fetchPlannerScenarios(workspaceId: string): Promise<PlannerScenario[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("planner_scenarios")
+    .select("id,name,status,objective,assumptions,created_at")
+    .eq("workspace_id", workspaceId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    name: row.name,
+    status: row.status,
+    objective: row.objective ?? {},
+    assumptions: row.assumptions ?? {},
+    createdAt: row.created_at
+  }));
+}

--- a/lib/data/reports.ts
+++ b/lib/data/reports.ts
@@ -1,0 +1,52 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+
+export type Report = {
+  id: string;
+  name: string;
+  cadence?: string | null;
+  recipients: string[];
+  status?: string | null;
+};
+
+export async function fetchReports(workspaceId: string): Promise<Report[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("reports")
+    .select("id,name,cadence,recipients")
+    .eq("workspace_id", workspaceId)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    name: row.name,
+    cadence: row.cadence,
+    recipients: row.recipients ?? []
+  }));
+}
+
+export async function fetchExports(workspaceId: string) {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("exports")
+    .select("id,status,created_at,report_id,reports(workspace_id,name)")
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? [])
+    .filter((row) => row.reports?.workspace_id === workspaceId)
+    .map((row) => ({
+      id: row.id,
+      status: row.status,
+      createdAt: row.created_at,
+      reportName: row.reports?.name ?? "",
+      reportId: row.report_id
+    }));
+}

--- a/lib/data/sync.ts
+++ b/lib/data/sync.ts
@@ -1,0 +1,33 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+
+export type SyncJob = {
+  id: string;
+  provider: string;
+  status: string;
+  scheduledFor: string;
+  startedAt?: string | null;
+  finishedAt?: string | null;
+};
+
+export async function fetchSyncQueue(workspaceId: string): Promise<SyncJob[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("sync_jobs")
+    .select("id,provider,status,scheduled_for,started_at,finished_at")
+    .eq("workspace_id", workspaceId)
+    .order("scheduled_for", { ascending: false })
+    .limit(50);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []).map((row) => ({
+    id: row.id,
+    provider: row.provider,
+    status: row.status,
+    scheduledFor: row.scheduled_for,
+    startedAt: row.started_at,
+    finishedAt: row.finished_at
+  }));
+}

--- a/lib/data/territories.ts
+++ b/lib/data/territories.ts
@@ -1,0 +1,49 @@
+import { createServiceRoleClient } from "@/lib/supabase/server";
+
+export type TerritorySnapshot = {
+  territory: string;
+  spend: number;
+  roas: number | null;
+  lastObservedAt?: string | null;
+};
+
+export async function fetchTerritorySnapshots(workspaceId: string): Promise<TerritorySnapshot[]> {
+  const client = createServiceRoleClient();
+  const { data, error } = await client
+    .from("v_territory_performance")
+    .select("territory,spend,roas")
+    .eq("workspace_id", workspaceId)
+    .order("spend", { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  const { data: freshnessRows, error: freshnessError } = await client
+    .from("performance_daily")
+    .select("territory,observed_at")
+    .eq("workspace_id", workspaceId)
+    .not("territory", "is", null)
+    .order("observed_at", { ascending: false })
+    .limit(2000);
+
+  if (freshnessError) {
+    throw freshnessError;
+  }
+
+  const freshnessMap = new Map<string, string>();
+  for (const row of freshnessRows ?? []) {
+    if (row.territory && !freshnessMap.has(row.territory)) {
+      freshnessMap.set(row.territory, row.observed_at as string);
+    }
+  }
+
+  return (data ?? [])
+    .filter((row): row is typeof row & { territory: string } => Boolean(row.territory))
+    .map((row) => ({
+      territory: row.territory!,
+      spend: Number(row.spend ?? 0),
+      roas: row.roas == null ? null : Number(row.roas),
+      lastObservedAt: freshnessMap.get(row.territory!) ?? null
+    }));
+}

--- a/lib/mcp/registry.ts
+++ b/lib/mcp/registry.ts
@@ -1,0 +1,47 @@
+import rawRegistry from "@/data/mcp-registry.json";
+
+export type McpAuthVariable = {
+  name: string;
+  description: string;
+  required?: boolean;
+};
+
+export type McpRegistryEntry = {
+  slug: string;
+  label: string;
+  docs?: string;
+  transports: string[];
+  defaultServerUrl?: string;
+  defaultStatus?: string;
+  env?: {
+    serverUrl?: string;
+    status?: string;
+    authHeader?: string;
+  };
+  authVariables?: McpAuthVariable[];
+  notes?: string[];
+};
+
+export const mcpRegistry = rawRegistry as McpRegistryEntry[];
+
+const registryBySlug = new Map<string, McpRegistryEntry>(
+  mcpRegistry.map((entry) => [entry.slug.toLowerCase(), entry])
+);
+
+export function resolveMcpEntry(identifier?: string | null): McpRegistryEntry | undefined {
+  if (!identifier) {
+    return undefined;
+  }
+  const normalized = identifier.toLowerCase();
+  if (registryBySlug.has(normalized)) {
+    return registryBySlug.get(normalized);
+  }
+  return mcpRegistry.find((entry) => entry.label.toLowerCase() === normalized);
+}
+
+export function computeTransportLabel(entry: McpRegistryEntry | undefined, fallback: string): string {
+  if (!entry) {
+    return fallback;
+  }
+  return entry.transports.join(" · ");
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,28 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+function resolveBrowserSupabaseUrl() {
+  const directUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
+  if (directUrl) {
+    return directUrl;
+  }
+
+  const projectId = process.env.SUPABASE_PROJECT_ID;
+  if (projectId) {
+    return `https://${projectId}.supabase.co`;
+  }
+
+  throw new Error("Supabase URL is not configured. Set NEXT_PUBLIC_SUPABASE_URL, SUPABASE_URL or SUPABASE_PROJECT_ID.");
+}
+
+export function createBrowserSupabaseClient(): SupabaseClient {
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!anonKey) {
+    throw new Error("Supabase anonymous key is not configured. Set NEXT_PUBLIC_SUPABASE_ANON_KEY.");
+  }
+
+  return createClient(resolveBrowserSupabaseUrl(), anonKey, {
+    auth: {
+      persistSession: true
+    }
+  });
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,30 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+function resolveSupabaseUrl(): string {
+  const directUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (directUrl) {
+    return directUrl;
+  }
+
+  const projectId = process.env.SUPABASE_PROJECT_ID;
+  if (projectId) {
+    return `https://${projectId}.supabase.co`;
+  }
+
+  throw new Error(
+    "Supabase URL is not configured. Provide SUPABASE_URL, NEXT_PUBLIC_SUPABASE_URL or SUPABASE_PROJECT_ID."
+  );
+}
+
+export function createServiceRoleClient(): SupabaseClient {
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceKey) {
+    throw new Error("Supabase service role key is missing. Set SUPABASE_SERVICE_ROLE_KEY in the environment.");
+  }
+
+  return createClient(resolveSupabaseUrl(), serviceKey, {
+    auth: {
+      persistSession: false
+    }
+  });
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,14 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export function slugify(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "")
+    .replace(/-{2,}/g, "-")
+    .trim();
+}

--- a/lib/workspace.ts
+++ b/lib/workspace.ts
@@ -1,0 +1,109 @@
+import { randomUUID } from "crypto";
+
+import { type SupabaseClient } from "@supabase/supabase-js";
+
+import { slugify } from "@/lib/utils";
+
+const WORKSPACE_COOKIE = "orionpulse_workspace";
+
+function parseWorkspaceFromCookie(cookieHeader: string | null): string | null {
+  if (!cookieHeader) {
+    return null;
+  }
+  const cookiesList = cookieHeader.split(/;\s*/);
+  for (const entry of cookiesList) {
+    const [key, value] = entry.split("=");
+    if (key === WORKSPACE_COOKIE && value) {
+      return decodeURIComponent(value);
+    }
+  }
+  return null;
+}
+
+type WorkspaceCarrier = Pick<Headers, "get"> | Request;
+
+function getHeader(carrier: WorkspaceCarrier, key: string) {
+  if (carrier instanceof Request) {
+    return carrier.headers.get(key);
+  }
+  return carrier.get(key);
+}
+
+export async function resolveWorkspaceId(
+  carrier: WorkspaceCarrier,
+  supabase: SupabaseClient
+): Promise<string> {
+  const headerWorkspace = getHeader(carrier, "x-orionpulse-workspace");
+  if (headerWorkspace) {
+    return headerWorkspace;
+  }
+
+  const cookieHeader = getHeader(carrier, "cookie");
+  const cookieWorkspace = parseWorkspaceFromCookie(cookieHeader);
+  if (cookieWorkspace) {
+    return cookieWorkspace;
+  }
+
+  const envWorkspace = process.env.ORIONPULSE_WORKSPACE_ID;
+  if (envWorkspace) {
+    return envWorkspace;
+  }
+
+  const { data, error } = await supabase
+    .from("workspaces")
+    .select("id")
+    .order("created_at", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw error;
+  }
+
+  if (data?.id) {
+    return data.id;
+  }
+
+  const defaultName = process.env.ORIONPULSE_DEFAULT_WORKSPACE_NAME ?? "OrionPulse HQ";
+  const defaultSlugBase = slugify(defaultName) || "workspace";
+  const territoriesFromEnv = (process.env.ORIONPULSE_DEFAULT_TERRITORIES ?? "MQ,GP,GF")
+    .split(",")
+    .map((territory) => territory.trim())
+    .filter(Boolean);
+  const territories = territoriesFromEnv.length > 0 ? territoriesFromEnv : ["MQ", "GP", "GF"];
+
+  try {
+    const { data: created, error: creationError } = await supabase
+      .from("workspaces")
+      .insert({
+        name: defaultName,
+        slug: `${defaultSlugBase}-${randomUUID().slice(0, 8)}`,
+        territory: territories
+      })
+      .select("id")
+      .single();
+
+    if (creationError) {
+      throw creationError;
+    }
+
+    if (!created?.id) {
+      throw new Error("Workspace bootstrap failed. No identifier returned by Supabase.");
+    }
+
+    return created.id;
+  } catch (creationError) {
+    const { data: retry } = await supabase
+      .from("workspaces")
+      .select("id")
+      .order("created_at", { ascending: true })
+      .limit(1)
+      .maybeSingle();
+
+    if (retry?.id) {
+      return retry.id;
+    }
+
+    throw creationError;
+  }
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '2mb'
+    }
+  }
+};
+
+module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6280 @@
+{
+  "name": "orionpulse",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "orionpulse",
+      "version": "0.1.0",
+      "dependencies": {
+        "@supabase/supabase-js": "^2.45.0",
+        "@trpc/server": "^10.45.2",
+        "clsx": "^2.1.0",
+        "echarts": "^5.5.0",
+        "echarts-for-react": "^3.0.2",
+        "lucide-react": "^0.312.0",
+        "next": "14.2.3",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "zod": "^4.1.11"
+      },
+      "devDependencies": {
+        "@types/node": "20.11.27",
+        "@types/react": "18.2.21",
+        "@types/react-dom": "18.2.7",
+        "autoprefixer": "10.4.17",
+        "eslint": "8.57.0",
+        "eslint-config-next": "14.2.3",
+        "postcss": "8.4.35",
+        "tailwindcss": "3.4.3",
+        "typescript": "5.4.2"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
+      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
+      "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA==",
+      "license": "MIT"
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.3.tgz",
+      "integrity": "sha512-L3oDricIIjgj1AVnRdRor21gI7mShlSwU/1ZGHmqM3LzHhXXhdkrfeNY5zif25Bi5Dd7fiJHsbhoZCHfXYvlAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "10.3.10"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.3.tgz",
+      "integrity": "sha512-3pEYo/RaGqPP0YzwnlmPN2puaF2WMLM3apt5jLW2fFdXD9+pqcoTzRk+iZsf8ta7+quAe4Q6Ms0nR0SFGFdS1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.3.tgz",
+      "integrity": "sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.3.tgz",
+      "integrity": "sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.3.tgz",
+      "integrity": "sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.3.tgz",
+      "integrity": "sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.3.tgz",
+      "integrity": "sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.3.tgz",
+      "integrity": "sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.3.tgz",
+      "integrity": "sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.3.tgz",
+      "integrity": "sha512-Q1/zm43RWynxrO7lW4ehciQVj+5ePBhOK+/K2P7pLFX3JaJ/IZVC69SHidrmZSOkqz7ECIOhhy7XhAFG4JYyHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rushstack/eslint-patch": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
+      "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.72.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.72.0.tgz",
+      "integrity": "sha512-4+bnUrtTDK1YD0/FCx2YtMiQH5FGu9Jlf4IQi5kcqRwRwqp2ey39V61nHNdH86jm3DIzz0aZKiWfTW8qXk1swQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.5.0.tgz",
+      "integrity": "sha512-SXBx6Jvp+MOBekeKFu+G11YLYPeVeGQl23eYyAG9+Ro0pQ1aIP0UZNIBxHKNHqxzR0L0n6gysNr2KT3841NATw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.2.tgz",
+      "integrity": "sha512-SiySHxi3q7gia7NBYpsYRu8gyI0NhFwSORMxbZIxJ/zAVkN6QpwDRan158CJ+UdzD4WB/rQMAGRqIJQP+7ccAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.58.0.tgz",
+      "integrity": "sha512-Tm1RmQpoAKdQr4/8wiayGti/no+If7RtveVZjHR8zbO7hhQjmPW2Ok5ZBPf1MGkt5c+9R85AVMsTfSaqAP1sUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.72.0",
+        "@supabase/functions-js": "2.5.0",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.2"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@trpc/server": {
+      "version": "10.45.2",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-10.45.2.tgz",
+      "integrity": "sha512-wOrSThNNE4HUnuhJG6PfDRp4L2009KDVxsd+2VYH8ro6o/7/jwYZ8Uu5j+VaW+mOmc8EHerHzGcdbGNQSAUPgg==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.11.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.27.tgz",
+      "integrity": "sha512-qyUZfMnCg1KEz57r7pzFtSGt49f6RPkPBis3Vo4PbS7roQEDn22hiHzl/Lo1q4i4hDEgBJmBF/NTNg2XR0HbFg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.2.21",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.21.tgz",
+      "integrity": "sha512-neFKG/sBAwGxHgXiIxnbm3/AAVQ/cMRS93hvBpg8xYRbeQSPVABp9U2bRnPf0iI4+Ucdv3plSxKK+3CW2ENJxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.7.tgz",
+      "integrity": "sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.2.0.tgz",
+      "integrity": "sha512-5FKsVcHTk6TafQKQbuIVkXq58Fnbkd2wDL4LB7AURN7RUOu1utVP+G8+6u3ZhEroW3DF6hyo3ZEXxgKgp4KeCg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.2.0",
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/typescript-estree": "7.2.0",
+        "@typescript-eslint/visitor-keys": "7.2.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.2.0.tgz",
+      "integrity": "sha512-Qh976RbQM/fYtjx9hs4XkayYujB/aPwglw2choHmf3zBjB4qOywWSdt9+KLRdHubGcoSwBnXUH2sR3hkyaERRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/visitor-keys": "7.2.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.2.0.tgz",
+      "integrity": "sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.2.0.tgz",
+      "integrity": "sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.2.0",
+        "@typescript-eslint/visitor-keys": "7.2.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.2.0.tgz",
+      "integrity": "sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.2.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.17",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.17.tgz",
+      "integrity": "sha512-/cpVNRLSfhOtcGflT13P2794gVSgmPgTR+erw5ifnMLZb0UnSlkK4tquLmkd3BhA+nLo5tX8Cu0upUsGKvKbmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.22.2",
+        "caniuse-lite": "^1.0.30001578",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.7.tgz",
+      "integrity": "sha512-bxxN2M3a4d1CRoQC//IqsR5XrLh0IJ8TCv2x6Y9N0nckNz/rTjZB3//GGscZziZOxmjP55rzxg/ze7usFI9FqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
+      "integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.3",
+        "caniuse-lite": "^1.0.30001741",
+        "electron-to-chromium": "^1.5.218",
+        "node-releases": "^2.0.21",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001745",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001745.tgz",
+      "integrity": "sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/echarts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.1"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.2.tgz",
+      "integrity": "sha512-DRwIiTzx8JfwPOVgGttDytBqdp5VzCSyMRIxubgU/g2n9y3VLUmF2FK7Icmg/sNVkv4+rktmrLN9w22U2yy3fA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.224",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.224.tgz",
+      "integrity": "sha512-kWAoUu/bwzvnhpdZSIc6KUyvkI1rbRXMT0Eq8pKReyOyaPZcctMli+EgvcN1PAvwVc7Tdo4Fxi2PsLNDU05mdg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.1.tgz",
+      "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.0.3",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.6",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.4",
+        "safe-array-concat": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
+      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.0",
+        "@humanwhocodes/config-array": "^0.11.14",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-next": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.3.tgz",
+      "integrity": "sha512-ZkNztm3Q7hjqvB1rRlOX8P9E/cXRL9ajRcs8jufEtwMfTVYRqnmtnaSu57QqHyBlovMuiB8LEzfLBkh5RYV6Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "14.2.3",
+        "@rushstack/eslint-patch": "^1.3.3",
+        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || 7.0.0 - 7.2.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.28.1",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-react": "^7.33.2",
+        "eslint-plugin-react-hooks": "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
+      },
+      "peerDependencies": {
+        "eslint": "^7.23.0 || ^8.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.0.0-canary-7118f5dd7-20230705",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0-canary-7118f5dd7-20230705.tgz",
+      "integrity": "sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/resolve": {
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.0",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.312.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.312.0.tgz",
+      "integrity": "sha512-3UZsqyswRXjW4t+nw+InICewSimjPKHuSxiFYqTshv9xkK3tPPntXk/lvXc9pKlXIxm3v9WKyoxcrB6YHhP+dg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.3.tgz",
+      "integrity": "sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/next": {
+      "version": "14.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.3.tgz",
+      "integrity": "sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.3",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.3",
+        "@next/swc-darwin-x64": "14.2.3",
+        "@next/swc-linux-arm64-gnu": "14.2.3",
+        "@next/swc-linux-arm64-musl": "14.2.3",
+        "@next/swc-linux-x64-gnu": "14.2.3",
+        "@next/swc-linux-x64-musl": "14.2.3",
+        "@next/swc-win32-arm64-msvc": "14.2.3",
+        "@next/swc-win32-ia32-msvc": "14.2.3",
+        "@next/swc-win32-x64-msvc": "14.2.3"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
+      "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/size-sensor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.2.tgz",
+      "integrity": "sha512-2NCmWxY7A9pYKGXNBfteo4hy14gWu47rg5692peVMst6lQLPKrVjhY+UTEsPI5ceFRJSl3gVgMYaUi/hKuaiKw==",
+      "license": "ISC"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "glob": "^10.3.10",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.3.tgz",
+      "integrity": "sha512-U7sxQk/n397Bmx4JHbJx/iSOOv5G+II3f1kpLpY2QeUv5DcPdcTsYLlusZfq1NthHS1c1cZoyFmmkex1rzke0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.5.3",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.0",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.0",
+        "lilconfig": "^2.1.0",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.23",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.1",
+        "postcss-nested": "^6.0.1",
+        "postcss-selector-parser": "^6.0.11",
+        "resolve": "^1.22.2",
+        "sucrase": "^3.32.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-load-config": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.0.0",
+        "yaml": "^2.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "postcss": ">=8.0.9",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-load-config/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zrender": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "orionpulse",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "db:push": "supabase db push --linked",
+    "db:reset": "supabase db reset --force --linked",
+    "mcp:bootstrap": "node scripts/bootstrap-mcp.js"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.0",
+    "@trpc/server": "^10.45.2",
+    "clsx": "^2.1.0",
+    "echarts": "^5.5.0",
+    "echarts-for-react": "^3.0.2",
+    "lucide-react": "^0.312.0",
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "zod": "^4.1.11"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.27",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "autoprefixer": "10.4.17",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "8.4.35",
+    "tailwindcss": "3.4.3",
+    "typescript": "5.4.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/scripts/bootstrap-mcp.js
+++ b/scripts/bootstrap-mcp.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const { createClient } = require("@supabase/supabase-js");
+const { randomUUID } = require("crypto");
+const registry = require("../data/mcp-registry.json");
+
+function resolveSupabaseUrl() {
+  if (process.env.SUPABASE_URL) {
+    return process.env.SUPABASE_URL;
+  }
+  if (process.env.NEXT_PUBLIC_SUPABASE_URL) {
+    return process.env.NEXT_PUBLIC_SUPABASE_URL;
+  }
+  if (process.env.SUPABASE_PROJECT_ID) {
+    return `https://${process.env.SUPABASE_PROJECT_ID}.supabase.co`;
+  }
+  throw new Error("Supabase URL is not configured (SUPABASE_URL or SUPABASE_PROJECT_ID required)");
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+async function ensureWorkspaceId(client) {
+  if (process.env.ORIONPULSE_WORKSPACE_ID) {
+    return process.env.ORIONPULSE_WORKSPACE_ID;
+  }
+
+  const { data, error } = await client
+    .from("workspaces")
+    .select("id")
+    .order("created_at", { ascending: true })
+    .limit(1);
+
+  if (error) {
+    throw error;
+  }
+
+  if (data && data.length > 0 && data[0].id) {
+    return data[0].id;
+  }
+
+  const defaultName = process.env.ORIONPULSE_DEFAULT_WORKSPACE_NAME || "OrionPulse HQ";
+  const slugBase = slugify(defaultName) || "workspace";
+  const territories = (process.env.ORIONPULSE_DEFAULT_TERRITORIES || "MQ,GP,GF")
+    .split(",")
+    .map((territory) => territory.trim())
+    .filter(Boolean);
+
+  const { data: created, error: insertError } = await client
+    .from("workspaces")
+    .insert({
+      name: defaultName,
+      slug: `${slugBase}-${randomUUID().slice(0, 8)}`,
+      territory: territories.length > 0 ? territories : ["MQ", "GP", "GF"]
+    })
+    .select("id")
+    .single();
+
+  if (insertError) {
+    throw insertError;
+  }
+
+  return created.id;
+}
+
+async function upsertMcpConnection(client, workspaceId, entry) {
+  const serverUrl = (entry.env?.serverUrl && process.env[entry.env.serverUrl]) || entry.defaultServerUrl || "";
+  const statusOverride = entry.env?.status ? process.env[entry.env.status] : null;
+  const status = statusOverride || (serverUrl ? entry.defaultStatus || "unknown" : "offline");
+  const now = new Date().toISOString();
+
+  const { error } = await client
+    .from("mcp_connections")
+    .upsert(
+      {
+        workspace_id: workspaceId,
+        provider: entry.slug,
+        server_url: serverUrl,
+        status,
+        last_health_check: status === "online" ? now : null,
+        metadata: {
+          label: entry.label,
+          transports: entry.transports,
+          docs: entry.docs ?? null,
+          env: entry.env ?? null
+        }
+      },
+      { onConflict: "workspace_id,provider" }
+    );
+
+  if (error) {
+    throw error;
+  }
+
+  return { status, serverUrl };
+}
+
+async function upsertDataSource(client, workspaceId, entry, statusSummary) {
+  const configured = statusSummary.serverUrl && statusSummary.serverUrl.length > 0;
+  const dsStatus = configured ? (statusSummary.status === "online" ? "active" : "configured") : "pending";
+
+  const { error } = await client
+    .from("data_sources")
+    .upsert(
+      {
+        workspace_id: workspaceId,
+        provider: entry.slug,
+        status: dsStatus,
+        settings: {
+          label: entry.label,
+          transports: entry.transports,
+          docs: entry.docs ?? null,
+          env: entry.env ?? null,
+          authVariables: entry.authVariables ?? [],
+          notes: entry.notes ?? []
+        }
+      },
+      { onConflict: "workspace_id,provider" }
+    );
+
+  if (error) {
+    throw error;
+  }
+}
+
+async function main() {
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceKey) {
+    throw new Error("SUPABASE_SERVICE_ROLE_KEY must be defined to bootstrap MCP connectors");
+  }
+
+  const client = createClient(resolveSupabaseUrl(), serviceKey, { auth: { persistSession: false } });
+  const workspaceId = await ensureWorkspaceId(client);
+
+  console.log(`▶️ Workspace ciblé : ${workspaceId}`);
+
+  for (const entry of registry) {
+    console.log(`⚙️  Synchronisation ${entry.label} (${entry.slug})`);
+    const statusSummary = await upsertMcpConnection(client, workspaceId, entry);
+    await upsertDataSource(client, workspaceId, entry, statusSummary);
+    console.log(
+      `   ↳ status=${statusSummary.status} url=${statusSummary.serverUrl || "(non configuré)"}`
+    );
+  }
+
+  console.log("✅ Connecteurs MCP alignés. Vérifiez le dashboard Admin pour confirmer.");
+}
+
+main().catch((error) => {
+  console.error("❌ Bootstrap MCP échoué", error);
+  process.exit(1);
+});

--- a/server/api/root.ts
+++ b/server/api/root.ts
@@ -1,0 +1,10 @@
+import { t } from "@/server/api/trpc";
+import { performanceRouter } from "@/server/api/routers/performance";
+import { opportunitiesRouter } from "@/server/api/routers/opportunities";
+
+export const appRouter = t.router({
+  performance: performanceRouter,
+  opportunities: opportunitiesRouter
+});
+
+export type AppRouter = typeof appRouter;

--- a/server/api/routers/opportunities.ts
+++ b/server/api/routers/opportunities.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+import { t } from "@/server/api/trpc";
+
+const opportunityInput = z.object({
+  title: z.string().min(3, "Titre trop court"),
+  summary: z.string().min(3).max(2000).optional(),
+  impact: z.number().min(0).max(1),
+  territory: z.string(),
+  runbookId: z.string().uuid().optional()
+});
+
+export const opportunitiesRouter = t.router({
+  queue: t.procedure.input(opportunityInput).mutation(async ({ ctx, input }) => {
+    let insightId: string | null = null;
+
+    if (input.summary) {
+      const { data: insight, error: insightError } = await ctx.supabase
+        .from("insights")
+        .insert({
+          workspace_id: ctx.workspaceId,
+          title: input.title,
+          body: input.summary,
+          impact: input.impact,
+          territory: input.territory,
+          status: "generated"
+        })
+        .select("id")
+        .single();
+
+      if (insightError) {
+        throw insightError;
+      }
+
+      insightId = insight?.id ?? null;
+    }
+
+    const { data, error } = await ctx.supabase
+      .from("opportunities")
+      .insert({
+        workspace_id: ctx.workspaceId,
+        title: input.title,
+        summary: input.summary ?? null,
+        score: input.impact,
+        status: "backlog",
+        territory: input.territory,
+        insight_id: insightId,
+        eta: null
+      })
+      .select("id")
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    if (input.runbookId) {
+      await ctx.supabase.from("approvals").insert({
+        workspace_id: ctx.workspaceId,
+        opportunity_id: data.id,
+        status: "pending",
+        payload: { requested_runbook: input.runbookId }
+      });
+    }
+
+    return {
+      id: data.id,
+      status: "queued",
+      insightId
+    };
+  }),
+  list: t.procedure.query(async ({ ctx }) => {
+    const { data, error } = await ctx.supabase
+      .from("opportunities")
+      .select("id,title,summary,score,status,territory,eta,insight_id")
+      .eq("workspace_id", ctx.workspaceId)
+      .order("created_at", { ascending: false });
+
+    if (error) {
+      throw error;
+    }
+
+    return data ?? [];
+  })
+});

--- a/server/api/routers/performance.ts
+++ b/server/api/routers/performance.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import { t } from "@/server/api/trpc";
+
+const filtersSchema = z.object({
+  territory: z.string().optional(),
+  channel: z.string().optional(),
+  startDate: z.string().optional(),
+  endDate: z.string().optional()
+});
+
+export const performanceRouter = t.router({
+  list: t.procedure
+    .input(filtersSchema)
+    .query(async ({ ctx, input }) => {
+      let query = ctx.supabase
+        .from("v_kpi_daily")
+        .select("observed_at,platform,territory,spend,impressions,clicks,conversions,revenue,cpa,roas")
+        .eq("workspace_id", ctx.workspaceId)
+        .order("observed_at", { ascending: false })
+        .limit(200);
+
+      if (input.territory) {
+        query = query.eq("territory", input.territory);
+      }
+      if (input.channel) {
+        query = query.eq("platform", input.channel);
+      }
+      if (input.startDate) {
+        query = query.gte("observed_at", input.startDate);
+      }
+      if (input.endDate) {
+        query = query.lte("observed_at", input.endDate);
+      }
+
+      const { data, error } = await query;
+      if (error) {
+        throw error;
+      }
+
+      return data ?? [];
+    }),
+  export: t.procedure
+    .input(filtersSchema.extend({ format: z.enum(["csv", "xlsx", "pdf"]) }))
+    .mutation(async ({ ctx, input }) => {
+      const { data, error } = await ctx.supabase
+        .from("sync_jobs")
+        .insert({
+          workspace_id: ctx.workspaceId,
+          provider: "semantic-export",
+          status: "queued",
+          scheduled_for: new Date().toISOString(),
+          payload: {
+            type: "performance",
+            format: input.format,
+            filters: input
+          }
+        })
+        .select("id")
+        .single();
+
+      if (error) {
+        throw error;
+      }
+
+      return {
+        jobId: data.id,
+        status: "queued"
+      };
+    })
+});

--- a/server/api/trpc.ts
+++ b/server/api/trpc.ts
@@ -1,0 +1,38 @@
+import { initTRPC } from "@trpc/server";
+import { type SupabaseClient } from "@supabase/supabase-js";
+import { ZodError } from "zod";
+
+import { createServiceRoleClient } from "@/lib/supabase/server";
+import { resolveWorkspaceId } from "@/lib/workspace";
+
+export type Context = {
+  supabase: SupabaseClient;
+  workspaceId: string;
+  userId?: string;
+};
+
+export const t = initTRPC.context<Context>().create({
+  errorFormatter({ shape, error }) {
+    return {
+      ...shape,
+      data: {
+        ...shape.data,
+        zodError: error.cause instanceof ZodError ? error.cause.flatten() : null
+      }
+    };
+  }
+});
+
+export async function createContext({ req }: { req: Request }): Promise<Context> {
+  const supabase = createServiceRoleClient();
+  const workspaceId = await resolveWorkspaceId(req, supabase);
+
+  const authHeader = req.headers.get("authorization");
+  const userId = authHeader?.startsWith("Bearer ") ? authHeader.split(" ")[1] : undefined;
+
+  return {
+    supabase,
+    workspaceId,
+    userId
+  };
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,8 @@
+project_id = "jqhmxrzzqzlwongbrdio"
+
+[db]
+shadow_database_url = "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+
+[auth]
+site_url = "http://localhost:3000"
+additional_redirect_urls = ["http://localhost:3000/auth/callback"]

--- a/supabase/migrations/202409250001_core.sql
+++ b/supabase/migrations/202409250001_core.sql
@@ -1,0 +1,174 @@
+-- OrionPulse core schema aligned with ARCHITECTURE.md
+create extension if not exists "uuid-ossp";
+create table if not exists workspaces (
+  id uuid primary key default uuid_generate_v4(),
+  name text not null,
+  territory text[] default array[]::text[],
+  created_at timestamptz default now()
+);
+
+create table if not exists users (
+  id uuid primary key default uuid_generate_v4(),
+  email text not null unique,
+  full_name text,
+  created_at timestamptz default now()
+);
+
+create table if not exists memberships (
+  workspace_id uuid references workspaces(id) on delete cascade,
+  user_id uuid references users(id) on delete cascade,
+  role text not null,
+  territories text[] default array[]::text[],
+  primary key (workspace_id, user_id)
+);
+
+create table if not exists data_sources (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  provider text not null,
+  status text not null,
+  settings jsonb default '{}'::jsonb,
+  created_at timestamptz default now()
+);
+
+create table if not exists credentials (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  provider text not null,
+  encrypted_payload text not null,
+  expires_at timestamptz,
+  created_at timestamptz default now()
+);
+
+create table if not exists mcp_connections (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  provider text not null,
+  server_url text not null,
+  status text not null,
+  last_health_check timestamptz,
+  created_at timestamptz default now()
+);
+
+create table if not exists sync_jobs (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  provider text not null,
+  status text not null,
+  scheduled_for timestamptz not null,
+  started_at timestamptz,
+  finished_at timestamptz,
+  payload jsonb default '{}'::jsonb
+);
+
+create table if not exists sync_logs (
+  id uuid primary key default uuid_generate_v4(),
+  job_id uuid references sync_jobs(id) on delete cascade,
+  level text not null,
+  message text not null,
+  meta jsonb default '{}'::jsonb,
+  created_at timestamptz default now()
+);
+
+create table if not exists insights (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  title text not null,
+  body text not null,
+  impact numeric,
+  territory text,
+  status text default 'draft',
+  created_at timestamptz default now()
+);
+
+create table if not exists opportunities (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  insight_id uuid references insights(id) on delete set null,
+  score numeric,
+  status text default 'backlog',
+  owner uuid references users(id),
+  territory text,
+  eta date,
+  created_at timestamptz default now()
+);
+
+create table if not exists approvals (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  opportunity_id uuid references opportunities(id) on delete set null,
+  status text not null,
+  approver uuid references users(id),
+  approved_at timestamptz,
+  payload jsonb default '{}'::jsonb
+);
+
+create table if not exists alert_rules (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  name text not null,
+  channel text not null,
+  threshold jsonb not null,
+  created_at timestamptz default now()
+);
+
+create table if not exists alert_events (
+  id uuid primary key default uuid_generate_v4(),
+  rule_id uuid references alert_rules(id) on delete cascade,
+  payload jsonb not null,
+  status text default 'open',
+  triggered_at timestamptz default now()
+);
+
+create table if not exists runbooks (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  name text not null,
+  definition jsonb not null,
+  created_at timestamptz default now()
+);
+
+create table if not exists playbook_executions (
+  id uuid primary key default uuid_generate_v4(),
+  runbook_id uuid references runbooks(id) on delete cascade,
+  triggered_by uuid references users(id),
+  status text not null,
+  logs jsonb default '[]'::jsonb,
+  created_at timestamptz default now()
+);
+
+create table if not exists reports (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  name text not null,
+  template jsonb not null,
+  cadence text,
+  recipients text[] default array[]::text[],
+  created_at timestamptz default now()
+);
+
+create table if not exists exports (
+  id uuid primary key default uuid_generate_v4(),
+  report_id uuid references reports(id) on delete cascade,
+  status text not null,
+  storage_path text,
+  created_at timestamptz default now()
+);
+
+create table if not exists copilot_sessions (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  territory text,
+  created_at timestamptz default now()
+);
+
+create table if not exists copilot_messages (
+  id uuid primary key default uuid_generate_v4(),
+  session_id uuid references copilot_sessions(id) on delete cascade,
+  role text not null,
+  content text not null,
+  created_at timestamptz default now()
+);
+
+comment on table opportunities is 'Prioritised actions orchestrated from anomaly detection and GPT-5 insights';
+comment on table approvals is 'Guardrail approvals for MCP actions (budget shifts, pauses)';

--- a/supabase/migrations/202409250002_performance.sql
+++ b/supabase/migrations/202409250002_performance.sql
@@ -1,0 +1,64 @@
+-- Performance metrics and supporting views for OrionPulse
+create table if not exists performance_daily (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  observed_at date not null,
+  platform text not null,
+  campaign text,
+  adset text,
+  ad text,
+  territory text,
+  spend numeric default 0,
+  impressions bigint default 0,
+  clicks bigint default 0,
+  conversions numeric default 0,
+  revenue numeric default 0,
+  currency text default 'EUR',
+  created_at timestamptz default now()
+);
+
+create index if not exists performance_daily_workspace_date_idx
+  on performance_daily (workspace_id, observed_at desc);
+
+create view if not exists v_kpi_daily as
+select
+  workspace_id,
+  observed_at,
+  territory,
+  platform,
+  sum(spend) as spend,
+  sum(impressions) as impressions,
+  sum(clicks) as clicks,
+  sum(conversions) as conversions,
+  sum(revenue) as revenue,
+  case when sum(clicks) > 0 then sum(spend) / sum(clicks) else null end as cpc,
+  case when sum(impressions) > 0 then sum(clicks)::numeric / sum(impressions) else null end as ctr,
+  case when sum(conversions) > 0 then sum(spend) / sum(conversions) else null end as cpa,
+  case when sum(spend) > 0 then sum(revenue) / sum(spend) else null end as roas
+from performance_daily
+group by workspace_id, observed_at, territory, platform;
+
+create view if not exists v_kpi_summary as
+select
+  workspace_id,
+  observed_at,
+  sum(spend) as total_spend,
+  sum(clicks) as total_clicks,
+  sum(conversions) as total_conversions,
+  sum(revenue) as total_revenue,
+  case when sum(clicks) > 0 then sum(spend) / sum(clicks) else null end as avg_cpc,
+  case when sum(impressions) > 0 then sum(clicks)::numeric / sum(impressions) else null end as avg_ctr,
+  case when sum(conversions) > 0 then sum(spend) / sum(conversions) else null end as avg_cpa,
+  case when sum(spend) > 0 then sum(revenue) / sum(spend) else null end as avg_roas
+from performance_daily
+group by workspace_id, observed_at;
+
+create view if not exists v_territory_performance as
+select
+  workspace_id,
+  territory,
+  sum(spend) as spend,
+  case when sum(spend) > 0 then sum(revenue) / sum(spend) else null end as roas
+from performance_daily
+where territory is not null
+group by workspace_id, territory;

--- a/supabase/migrations/202409250003_operational.sql
+++ b/supabase/migrations/202409250003_operational.sql
@@ -1,0 +1,79 @@
+-- Additional operational tables supporting dashboards
+create table if not exists anomaly_events (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  detected_at timestamptz not null default now(),
+  severity text not null,
+  status text not null default 'open',
+  dimension jsonb default '{}'::jsonb,
+  runbook_id uuid references runbooks(id),
+  description text
+);
+
+create table if not exists creative_assets (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  external_id text,
+  platform text not null,
+  name text not null,
+  thumbnail_url text,
+  status text default 'active',
+  last_seen_at timestamptz,
+  metrics jsonb default '{}'::jsonb,
+  created_at timestamptz default now()
+);
+
+create table if not exists creative_analysis (
+  id uuid primary key default uuid_generate_v4(),
+  asset_id uuid references creative_assets(id) on delete cascade,
+  fatigue_score numeric,
+  highlights text,
+  tags text[] default array[]::text[],
+  updated_at timestamptz default now()
+);
+
+create table if not exists planner_scenarios (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  name text not null,
+  status text not null default 'draft',
+  objective jsonb default '{}'::jsonb,
+  assumptions jsonb default '{}'::jsonb,
+  created_at timestamptz default now()
+);
+
+create table if not exists lift_tests (
+  id uuid primary key default uuid_generate_v4(),
+  workspace_id uuid references workspaces(id) on delete cascade,
+  name text not null,
+  status text not null default 'draft',
+  start_date date,
+  end_date date,
+  hypothesis text,
+  platform text,
+  territory text,
+  created_at timestamptz default now()
+);
+
+create view if not exists v_active_alerts as
+select
+  ae.id,
+  ar.workspace_id,
+  ar.name,
+  ae.payload,
+  ae.status,
+  ae.triggered_at
+from alert_events ae
+join alert_rules ar on ar.id = ae.rule_id
+where ae.status = 'open';
+
+create view if not exists v_sync_status as
+select
+  workspace_id,
+  provider,
+  status,
+  max(started_at) as last_started,
+  max(finished_at) as last_finished,
+  max(scheduled_for) as next_run
+from sync_jobs
+group by workspace_id, provider, status;

--- a/supabase/migrations/202409250004_backend_hardening.sql
+++ b/supabase/migrations/202409250004_backend_hardening.sql
@@ -1,0 +1,331 @@
+-- Backend hardening: workspace slugs, opportunity metadata and RLS policies
+
+-- Workspace slug alignment with architecture blueprint
+alter table workspaces add column if not exists slug text;
+
+update workspaces
+set slug = coalesce(
+    slug,
+    concat_ws(
+      '-',
+      nullif(regexp_replace(lower(coalesce(name, 'workspace')), '[^a-z0-9]+', '-', 'g'), ''),
+      substr(id::text, 1, 8)
+    )
+  )
+where slug is null;
+
+update workspaces
+set slug = concat('workspace-', substr(id::text, 1, 8))
+where slug is null;
+
+alter table workspaces alter column slug set not null;
+alter table workspaces add constraint workspaces_slug_key unique (slug);
+
+-- Opportunity metadata surfaced in UI and API
+alter table opportunities add column if not exists title text;
+alter table opportunities add column if not exists summary text;
+
+update opportunities as o
+set title = coalesce(o.title, i.title)
+from insights i
+where o.insight_id = i.id
+  and (o.title is null or o.title = '');
+
+update opportunities
+set title = coalesce(title, 'Opportunity')
+where title is null or title = '';
+
+update opportunities as o
+set summary = coalesce(o.summary, i.body)
+from insights i
+where o.insight_id = i.id
+  and (o.summary is null or o.summary = '');
+
+alter table opportunities alter column title set not null;
+
+-- Helper predicate used by RLS policies
+create or replace function public.is_workspace_member(workspace uuid)
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+  select auth.uid() is not null
+    and exists (
+      select 1
+      from memberships m
+      where m.workspace_id = workspace
+        and m.user_id = auth.uid()
+    );
+$$;
+
+comment on function public.is_workspace_member is 'Returns true when the authenticated user belongs to the provided workspace id.';
+
+-- Enable Row Level Security on core tables
+alter table workspaces enable row level security;
+alter table users enable row level security;
+alter table memberships enable row level security;
+alter table data_sources enable row level security;
+alter table credentials enable row level security;
+alter table mcp_connections enable row level security;
+alter table sync_jobs enable row level security;
+alter table sync_logs enable row level security;
+alter table performance_daily enable row level security;
+alter table insights enable row level security;
+alter table opportunities enable row level security;
+alter table approvals enable row level security;
+alter table alert_rules enable row level security;
+alter table alert_events enable row level security;
+alter table runbooks enable row level security;
+alter table playbook_executions enable row level security;
+alter table reports enable row level security;
+alter table exports enable row level security;
+alter table copilot_sessions enable row level security;
+alter table copilot_messages enable row level security;
+
+-- Core policies for workspace-scoped resources
+create policy "workspace_members_select_workspaces" on workspaces
+  for select using (public.is_workspace_member(id));
+
+create policy "workspace_members_select_users" on users
+  for select using (
+    id = auth.uid()
+    or exists (
+      select 1
+      from memberships m_self
+      join memberships m_other on m_self.workspace_id = m_other.workspace_id
+      where m_self.user_id = auth.uid()
+        and m_other.user_id = users.id
+    )
+  );
+
+create policy "workspace_members_modify_users" on users
+  for update using (id = auth.uid())
+  with check (id = auth.uid());
+
+create policy "workspace_members_insert_self" on users
+  for insert with check (id = auth.uid());
+
+create policy "workspace_members_select_memberships" on memberships
+  for select using (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_manage_memberships" on memberships
+  for update using (public.is_workspace_member(workspace_id))
+  with check (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_select_data_sources" on data_sources
+  for select using (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_manage_data_sources" on data_sources
+  for all using (public.is_workspace_member(workspace_id))
+  with check (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_select_credentials" on credentials
+  for select using (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_manage_credentials" on credentials
+  for all using (public.is_workspace_member(workspace_id))
+  with check (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_select_mcp_connections" on mcp_connections
+  for select using (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_manage_mcp_connections" on mcp_connections
+  for all using (public.is_workspace_member(workspace_id))
+  with check (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_select_sync_jobs" on sync_jobs
+  for select using (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_manage_sync_jobs" on sync_jobs
+  for all using (public.is_workspace_member(workspace_id))
+  with check (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_select_performance" on performance_daily
+  for select using (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_manage_performance" on performance_daily
+  for all using (public.is_workspace_member(workspace_id))
+  with check (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_select_insights" on insights
+  for select using (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_manage_insights" on insights
+  for all using (public.is_workspace_member(workspace_id))
+  with check (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_select_opportunities" on opportunities
+  for select using (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_manage_opportunities" on opportunities
+  for all using (public.is_workspace_member(workspace_id))
+  with check (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_select_approvals" on approvals
+  for select using (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_manage_approvals" on approvals
+  for all using (public.is_workspace_member(workspace_id))
+  with check (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_select_alert_rules" on alert_rules
+  for select using (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_manage_alert_rules" on alert_rules
+  for all using (public.is_workspace_member(workspace_id))
+  with check (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_select_runbooks" on runbooks
+  for select using (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_manage_runbooks" on runbooks
+  for all using (public.is_workspace_member(workspace_id))
+  with check (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_select_playbook_executions" on playbook_executions
+  for select using (
+    exists (
+      select 1
+      from runbooks r
+      where r.id = playbook_executions.runbook_id
+        and public.is_workspace_member(r.workspace_id)
+    )
+  );
+
+create policy "workspace_members_manage_playbook_executions" on playbook_executions
+  for all using (
+    exists (
+      select 1
+      from runbooks r
+      where r.id = playbook_executions.runbook_id
+        and public.is_workspace_member(r.workspace_id)
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from runbooks r
+      where r.id = playbook_executions.runbook_id
+        and public.is_workspace_member(r.workspace_id)
+    )
+  );
+
+create policy "workspace_members_select_reports" on reports
+  for select using (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_manage_reports" on reports
+  for all using (public.is_workspace_member(workspace_id))
+  with check (public.is_workspace_member(workspace_id));
+
+create policy "workspace_members_select_exports" on exports
+  for select using (
+    exists (
+      select 1
+      from reports r
+      where r.id = exports.report_id
+        and public.is_workspace_member(r.workspace_id)
+    )
+  );
+
+create policy "workspace_members_manage_exports" on exports
+  for all using (
+    exists (
+      select 1
+      from reports r
+      where r.id = exports.report_id
+        and public.is_workspace_member(r.workspace_id)
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from reports r
+      where r.id = exports.report_id
+        and public.is_workspace_member(r.workspace_id)
+    )
+  );
+
+create policy "workspace_members_select_copilot_sessions" on copilot_sessions
+  for select using (
+    workspace_id is null or public.is_workspace_member(workspace_id)
+  );
+
+create policy "workspace_members_manage_copilot_sessions" on copilot_sessions
+  for all using (
+    workspace_id is null or public.is_workspace_member(workspace_id)
+  )
+  with check (
+    workspace_id is null or public.is_workspace_member(workspace_id)
+  );
+
+create policy "workspace_members_select_copilot_messages" on copilot_messages
+  for select using (
+    exists (
+      select 1
+      from copilot_sessions s
+      where s.id = copilot_messages.session_id
+        and (s.workspace_id is null or public.is_workspace_member(s.workspace_id))
+    )
+  );
+
+create policy "workspace_members_manage_copilot_messages" on copilot_messages
+  for all using (
+    exists (
+      select 1
+      from copilot_sessions s
+      where s.id = copilot_messages.session_id
+        and (s.workspace_id is null or public.is_workspace_member(s.workspace_id))
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from copilot_sessions s
+      where s.id = copilot_messages.session_id
+        and (s.workspace_id is null or public.is_workspace_member(s.workspace_id))
+    )
+  );
+
+create policy "workspace_members_select_sync_logs" on sync_logs
+  for select using (
+    exists (
+      select 1
+      from sync_jobs j
+      where j.id = sync_logs.job_id
+        and public.is_workspace_member(j.workspace_id)
+    )
+  );
+
+create policy "workspace_members_select_alert_events" on alert_events
+  for select using (
+    exists (
+      select 1
+      from alert_rules ar
+      where ar.id = alert_events.rule_id
+        and public.is_workspace_member(ar.workspace_id)
+    )
+  );
+
+create policy "workspace_members_manage_alert_events" on alert_events
+  for all using (
+    exists (
+      select 1
+      from alert_rules ar
+      where ar.id = alert_events.rule_id
+        and public.is_workspace_member(ar.workspace_id)
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from alert_rules ar
+      where ar.id = alert_events.rule_id
+        and public.is_workspace_member(ar.workspace_id)
+    )
+  );
+
+-- Ensure derived views respect the caller security context
+alter view v_kpi_daily set (security_invoker = true);
+alter view v_kpi_summary set (security_invoker = true);
+alter view v_territory_performance set (security_invoker = true);

--- a/supabase/migrations/202409250005_mcp_registry.sql
+++ b/supabase/migrations/202409250005_mcp_registry.sql
@@ -1,0 +1,9 @@
+-- MCP registry alignment: metadata + unique indexes for upserts
+alter table mcp_connections
+  add column if not exists metadata jsonb default '{}'::jsonb;
+
+create unique index if not exists mcp_connections_workspace_provider_key
+  on mcp_connections (workspace_id, provider);
+
+create unique index if not exists data_sources_workspace_provider_key
+  on data_sources (workspace_id, provider);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,32 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: "#040910",
+        surface: "#0C1626",
+        accent: {
+          DEFAULT: "#5C7CFA",
+          muted: "#4E5DFF",
+          subtle: "#9BA5FF"
+        }
+      },
+      fontFamily: {
+        sans: ["Inter", "ui-sans-serif", "system-ui"],
+        mono: ["JetBrains Mono", "monospace"]
+      },
+      boxShadow: {
+        glass: "0 8px 32px rgba(0, 0, 0, 0.45)"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,53 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": [
+        "components/*"
+      ],
+      "@/lib/*": [
+        "lib/*"
+      ],
+      "@/app/*": [
+        "app/*"
+      ],
+      "@/server/*": [
+        "server/*"
+      ],
+      "@/data/*": [
+        "data/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- add a credentials data helper that fuses the MCP registry with Supabase Vault records to compute per-provider health statuses
- extend the admin control plane to display API/secret posture alongside connector and sync details so the UI reflects real backend state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5bf418530832c8d7fd78f1004998b