### PR TITLE
Normalize Supabase payload typing across dashboards

### DIFF
--- a/app/(dashboard)/alerts/page.tsx
+++ b/app/(dashboard)/alerts/page.tsx
@@ -10,10 +10,10 @@ import { resolveWorkspaceId } from "@/lib/workspace";
 type AlertRow = Awaited<ReturnType<typeof fetchAlertEvents>>[number];
 
 const columns: Column<AlertRow>[] = [
-  { header: "Règle", accessor: (row) => row.payload?.rule_name ?? row.ruleId },
+  { header: "Règle", accessor: (row) => row.payload.ruleName ?? row.ruleId },
   {
     header: "Impact",
-    accessor: (row) => row.payload?.impact ?? "—"
+    accessor: (row) => row.payload.impact ?? "—"
   },
   { header: "Statut", accessor: (row) => <Pill>{row.status}</Pill> },
   {

--- a/app/(dashboard)/anomalies/page.tsx
+++ b/app/(dashboard)/anomalies/page.tsx
@@ -7,9 +7,9 @@ import { createServiceRoleClient } from "@/lib/supabase/server";
 import { resolveWorkspaceId } from "@/lib/workspace";
 
 const columns: Column<Anomaly>[] = [
-  { header: "Type", accessor: (row) => row.dimension?.type ?? "Anomalie" },
-  { header: "Canal", accessor: (row) => row.dimension?.channel ?? "—" },
-  { header: "Territoire", accessor: (row) => row.dimension?.territory ?? "—" },
+  { header: "Type", accessor: (row) => row.dimension.type ?? "Anomalie" },
+  { header: "Canal", accessor: (row) => row.dimension.channel ?? "—" },
+  { header: "Territoire", accessor: (row) => row.dimension.territory ?? "—" },
   {
     header: "Détectée",
     accessor: (row) => new Date(row.detectedAt).toLocaleString("fr-FR")

--- a/app/(dashboard)/creatives/page.tsx
+++ b/app/(dashboard)/creatives/page.tsx
@@ -40,7 +40,14 @@ export default async function CreativesPage() {
               </div>
               <p className="text-sm text-slate-400">Plateforme : {creative.platform}</p>
               <p className="text-sm text-slate-300">
-                Fatigue : {creative.fatigueScore?.toFixed(1) ?? "—"} · Tags : {creative.tags.join(", ") || "—"}
+                Fatigue :
+                {creative.analysis.fatigueScore != null
+                  ? ` ${creative.analysis.fatigueScore.toFixed(1)}`
+                  : " —"}
+                {" "}· Tags :
+                {creative.analysis.tags.length > 0
+                  ? ` ${creative.analysis.tags.join(", ")}`
+                  : " —"}
               </p>
               <button className="inline-flex items-center justify-center rounded-full border border-white/10 px-4 py-2 text-xs text-slate-200 hover:border-accent-subtle">
                 Générer brief GPT-5

--- a/app/(dashboard)/overview/page.tsx
+++ b/app/(dashboard)/overview/page.tsx
@@ -50,9 +50,24 @@ export default async function OverviewPage() {
             Aucune donnée disponible pour le workspace. Lancez une synchronisation MCP pour alimenter les KPIs.
           </p>
         ) : (
-          kpiSummary.map((kpi) => (
-            <MetricCard key={kpi.label} label={kpi.label} value={kpi.value} delta={kpi.delta ?? undefined} />
-          ))
+          kpiSummary.map((kpi) => {
+            const formattedValue = kpi.value.toLocaleString("fr-FR", {
+              maximumFractionDigits: 2
+            });
+            const formattedDelta =
+              kpi.delta == null
+                ? "—"
+                : `${kpi.delta >= 0 ? "+" : ""}${kpi.delta.toFixed(1)}%`;
+
+            return (
+              <MetricCard
+                key={kpi.label}
+                label={kpi.label}
+                value={formattedValue}
+                delta={formattedDelta}
+              />
+            );
+          })
         )}
       </div>
 

--- a/components/charts/territory-chart.tsx
+++ b/components/charts/territory-chart.tsx
@@ -45,13 +45,15 @@ export function TerritoryChart({ data }: { data: TerritoryDatum[] }) {
         borderColor: "rgba(148, 163, 184, 0.2)",
         textStyle: { color: "#e2e8f0", fontSize: 12 },
         valueFormatter: (value, series) => {
-          if (series?.seriesName === "ROAS" && typeof value === "number") {
+          const seriesName = (series as { seriesName?: string } | undefined)?.seriesName;
+
+          if (seriesName === "ROAS" && typeof value === "number") {
             return `${value.toFixed(2)}x`;
           }
           if (typeof value === "number") {
             return `€${value.toLocaleString("fr-FR")}`;
           }
-          return value as string;
+          return value == null ? "—" : String(value);
         }
       },
       xAxis: {

--- a/lib/data/reports.ts
+++ b/lib/data/reports.ts
@@ -8,6 +8,14 @@ export type Report = {
   status?: string | null;
 };
 
+export type ReportExport = {
+  id: string;
+  status: string;
+  createdAt: string;
+  reportName: string;
+  reportId: string | null;
+};
+
 export async function fetchReports(workspaceId: string): Promise<Report[]> {
   const client = createServiceRoleClient();
   const { data, error } = await client
@@ -28,7 +36,7 @@ export async function fetchReports(workspaceId: string): Promise<Report[]> {
   }));
 }
 
-export async function fetchExports(workspaceId: string) {
+export async function fetchExports(workspaceId: string): Promise<ReportExport[]> {
   const client = createServiceRoleClient();
   const { data, error } = await client
     .from("exports")
@@ -40,13 +48,39 @@ export async function fetchExports(workspaceId: string) {
     throw error;
   }
 
+  type ExportRow = {
+    id: string;
+    status: string;
+    created_at: string;
+    report_id: string | null;
+    reports?:
+      | { workspace_id?: string | null; name?: string | null }
+      | ({ workspace_id?: string | null; name?: string | null } | null)[]
+      | null;
+  };
+
   return (data ?? [])
-    .filter((row) => row.reports?.workspace_id === workspaceId)
-    .map((row) => ({
-      id: row.id,
-      status: row.status,
-      createdAt: row.created_at,
-      reportName: row.reports?.name ?? "",
-      reportId: row.report_id
-    }));
+    .filter((row: ExportRow) => {
+      const relatedReports = Array.isArray(row.reports)
+        ? row.reports
+        : [row.reports];
+      return relatedReports.some((report) => report?.workspace_id === workspaceId);
+    })
+    .map((row: ExportRow) => {
+      const relatedReports = Array.isArray(row.reports)
+        ? row.reports.filter((report): report is { workspace_id?: string | null; name?: string | null } => Boolean(report))
+        : row.reports
+          ? [row.reports]
+          : [];
+
+      const report = relatedReports[0];
+
+      return {
+        id: row.id,
+        status: row.status,
+        createdAt: row.created_at,
+        reportName: report?.name ?? "",
+        reportId: row.report_id
+      } satisfies ReportExport;
+    });
 }


### PR DESCRIPTION
## Summary
- add a dedicated `AlertEventPayload` type and normalize Supabase alert payloads before rendering in the dashboard
- normalize additional Supabase relationship payloads (anomaly dimensions, creative analyses, opportunities, and report exports) and update the UI to consume typed fields
- polish KPI formatting, profile membership parsing, and chart tooltip typing to satisfy stricter type-checking

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5ec55c300832c8e2a0f4569733a40