### PR TITLE
Fix gradient border overlay intercepting clicks

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -36,4 +36,5 @@ a:hover {
   -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
+  pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- prevent the gradient border pseudo-element from capturing mouse events by disabling pointer events

## Testing
- npm run dev -- --hostname 0.0.0.0 --port 3000

------
https://chatgpt.com/codex/tasks/task_e_68d675a45404832c899418aadce43a23