### PR TITLE
Adjust gradient border stacking to restore button clicks

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,6 +24,7 @@ a:hover {
 
 .gradient-border {
   position: relative;
+  z-index: 0;
 }
 
 .gradient-border::before {
@@ -36,4 +37,6 @@ a:hover {
   -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
+  pointer-events: none;
+  z-index: -1;
 }


### PR DESCRIPTION
## Summary
- ensure gradient border container establishes its own stacking context
- place the pseudo-element behind interactive content while keeping it non-interactive

## Testing
- npm run lint *(fails: next not found in PATH because dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d675a45404832c899418aadce43a23